### PR TITLE
feat(claude): settings.json をリポジトリ管理化し symlink 配布に追加

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,7 +1,7 @@
 # グローバル CLAUDE.md
 
 全プロジェクト共通の個人規約。実体は setup リポジトリの `claude/CLAUDE.md`
-(tasks/claude.yml が `~/.claude/CLAUDE.md` へシンボリックリンク)。
+(settings.json とあわせて tasks/claude.yml が `~/.claude/` 配下へシンボリックリンク)。
 プロジェクト・リポジトリ固有の規約は各所の CLAUDE.md / CONTRIBUTING.md が正本で、
 ここでは繰り返さない。
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,44 @@
+{
+  "permissions": {
+    "allow": [],
+    "additionalDirectories": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // \"\"' | grep -qiE -- '--no-gpg-sign|gpgsign[[:space:]=]+(false|0)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"署名なしコミットは禁止(全コミット Verified 運用)。--no-gpg-sign / commit.gpgsign=false を使わず、既定のまま署名付きでコミットする(1Password の op-ssh-sign は非対話でも動作する)。\"}}' || true",
+            "timeout": 10,
+            "statusMessage": "コミット署名ポリシーを確認中"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "swift-lsp@claude-plugins-official": true,
+    "cloudflare@cloudflare": true
+  },
+  "extraKnownMarketplaces": {
+    "cosense-cli": {
+      "source": {
+        "source": "github",
+        "repo": "helpfeel/cosense-cli"
+      }
+    },
+    "cloudflare": {
+      "source": {
+        "source": "github",
+        "repo": "cloudflare/skills"
+      },
+      "autoUpdate": true
+    }
+  },
+  "language": "japanese",
+  "tui": "fullscreen",
+  "theme": "auto",
+  "agentPushNotifEnabled": true
+}

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -1,5 +1,11 @@
 ---
-# Claude Code グローバル設定 (CLAUDE.md) のリンク
+# Claude Code グローバル設定 (CLAUDE.md / settings.json) のリンク
+
+- name: Define Claude global config files
+  ansible.builtin.set_fact:
+    claude_config_files:
+      - CLAUDE.md
+      - settings.json
 
 - name: Create ~/.claude directory
   ansible.builtin.file:
@@ -7,22 +13,27 @@
     state: directory
     mode: "0700"
 
-- name: Check existing global CLAUDE.md
+- name: Check existing global config files
   ansible.builtin.stat:
-    path: "{{ ansible_facts['env']['HOME'] }}/.claude/CLAUDE.md"
-  register: global_claude_md
+    path: "{{ ansible_facts['env']['HOME'] }}/.claude/{{ item }}"
+  register: claude_config_stats
+  loop: "{{ claude_config_files }}"
 
-- name: Back up existing CLAUDE.md if it is a regular file
+- name: Back up existing config if it is a regular file
   ansible.builtin.copy:
-    src: "{{ ansible_facts['env']['HOME'] }}/.claude/CLAUDE.md"
-    dest: "{{ ansible_facts['env']['HOME'] }}/.claude/CLAUDE.md.bak-{{ ansible_facts['date_time']['date'] }}"
+    src: "{{ ansible_facts['env']['HOME'] }}/.claude/{{ item.item }}"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.claude/{{ item.item }}.bak-{{ ansible_facts['date_time']['date'] }}"
     remote_src: true
     mode: preserve
-  when: global_claude_md.stat.exists and not global_claude_md.stat.islnk
+  when: item.stat.exists and not item.stat.islnk
+  loop: "{{ claude_config_stats.results }}"
+  loop_control:
+    label: "{{ item.item }}"
 
-- name: Create symlink for global CLAUDE.md
+- name: Create symlinks for global config files
   ansible.builtin.file:
-    src: "{{ playbook_dir }}/claude/CLAUDE.md"
-    dest: "{{ ansible_facts['env']['HOME'] }}/.claude/CLAUDE.md"
+    src: "{{ playbook_dir }}/claude/{{ item }}"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.claude/{{ item }}"
     state: link
     force: true
+  loop: "{{ claude_config_files }}"


### PR DESCRIPTION
## 目的

Claude Code のグローバル設定のうち、これまでリポジトリ管理外だった `~/.claude/settings.json` を CLAUDE.md と同じ「リポジトリが正本 + symlink 配布」方式に載せる。マシン再構築時に以下が自動で再現されるようになる:

- コミット署名ポリシーの PreToolUse hook (署名なしコミットの拒否)
- プラグイン設定 (cloudflare/skills marketplace + cloudflare プラグイン、swift-lsp、cosense-cli marketplace)
- 言語・UI 設定 (japanese / fullscreen / auto theme)

あわせて、`~/.claude/skills/` に手動コピーしていた Cloudflare スキル 8 件は [cloudflare/skills](https://github.com/cloudflare/skills) の plugin marketplace 経由に移行済み (settings.json の `extraKnownMarketplaces` + `enabledPlugins` で宣言)。コピーの git 管理ではなく宣言の git 管理にすることで、上流の更新に autoUpdate で追従できる。

## 変更点

- `claude/settings.json`: 現行グローバル設定の実体を新規配置 (秘密情報なし。死んだ permissions.allow エントリは掃除済み)
- `tasks/claude.yml`: 対象ファイルを loop 化し、CLAUDE.md / settings.json を同一パターン (実ファイルならバックアップ→symlink) で処理
- `claude/CLAUDE.md`: 冒頭の管理方法の説明を settings.json 込みに更新

## 確認方法

- `ansible-playbook playbook_sillicon_mac.yml --syntax-check` → pass
- `ansible-playbook playbook_sillicon_mac.yml --tags claude --check` → CLAUDE.md はバックアップ skip (既に symlink)、settings.json はバックアップ + symlink が changed と評価されることを確認済み
- merge 後、main checkout から `ansible-playbook playbook_sillicon_mac.yml --tags claude` を実行して symlink 化する (playbook_dir 基準のため worktree からは実行しない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)