### PR TITLE
chore(zshrc): direnv hook を追加

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -114,3 +114,8 @@ _update_prompt_with_firebase
 
 
 export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+
+# direnv (.envrc を見てディレクトリ単位で環境を切替。metaphor-cli のローカル開発ビルド優先など)
+if command -v direnv >/dev/null 2>&1; then
+  eval "$(direnv hook zsh)"
+fi


### PR DESCRIPTION
## 目的

ローカルの zshrc に追加されていたが、コミットされずに残っていた変更を main へ回収する。#18 の作業中に main checkout の未コミット変更として発見。

## 変更点

- direnv がインストール済みの場合のみ `direnv hook zsh` を有効化 (5 行追加)。.envrc によるディレクトリ単位の環境切替 (metaphor-cli のローカル開発ビルド優先など) に使用

## 確認方法

- `zsh -n zshrc` で構文エラーがないこと
- direnv 未インストール環境でも `command -v` ガードにより無害であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)