### PR TITLE
feat(claude): RunCat Neo の statusLine 連携をリポジトリ管理化

### DIFF
--- a/claude/runcat-statusline.py
+++ b/claude/runcat-statusline.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+RunCat Neo — Claude Code statusLine sample.
+
+Writes ~/.claude/runcat-usage.json shaped like:
+
+    {
+      "title": "Claude Code",
+      "symbol": "staroflife",
+      "metricsBarValue": "67%",
+      "metrics": [
+        {"title": "Model",   "formattedValue": "Opus 4.7"},
+        {"title": "Context", "formattedValue": "67%", "normalizedValue": 0.67},
+        {"title": "5h",      "formattedValue": "3%",  "normalizedValue": 0.03},
+        {"title": "7d",      "formattedValue": "3%",  "normalizedValue": 0.03}
+      ],
+      "lastUpdatedDate": "2026-06-07T05:55:36Z"
+    }
+"""
+
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
+
+
+def pct(title, value):
+    if value is None:
+        return None
+    return {"title": title, "formattedValue": f"{value:g}%", "normalizedValue": round(value / 100, 4)}
+
+
+try:
+    payload = json.load(sys.stdin)
+    if not isinstance(payload, dict):
+        payload = {}
+except Exception:
+    payload = {}
+
+model = (payload.get("model") or {}).get("display_name") or "Claude Code"
+ctx = (payload.get("context_window") or {}).get("used_percentage")
+rate_limits = payload.get("rate_limits") or {}
+five = (rate_limits.get("five_hour") or {}).get("used_percentage")
+seven = (rate_limits.get("seven_day") or {}).get("used_percentage")
+
+snapshot = {
+    "title": "Claude Code",
+    "symbol": "staroflife",
+    "metrics": [m for m in [
+        {"title": "Model", "formattedValue": model},
+        pct("Context", ctx),
+        pct("5h", five),
+        pct("7d", seven),
+    ] if m is not None],
+    "lastUpdatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+}
+if ctx is not None:
+    snapshot["metricsBarValue"] = f"{ctx:g}%"
+
+OUT.parent.mkdir(parents=True, exist_ok=True)
+fd, tmp = tempfile.mkstemp(prefix=".runcat-", dir=str(OUT.parent))
+with os.fdopen(fd, "w", encoding="utf-8") as f:
+    json.dump(snapshot, f, ensure_ascii=False)
+os.replace(tmp, OUT)
+
+print(model)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -37,6 +37,10 @@
       "autoUpdate": true
     }
   },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/runcat-statusline.py"
+  },
   "language": "japanese",
   "tui": "fullscreen",
   "theme": "auto",

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -1,12 +1,16 @@
 ---
-# Claude Code グローバル設定 (CLAUDE.md / settings.json) と
+# Claude Code グローバル設定 (CLAUDE.md / settings.json / statusLine スクリプト) と
 # 全プロジェクト共通スキル (claude/skills/*) のリンク
 
+# runcat-statusline.py は RunCat Neo の Custom Metrics 連携 (statusLine から
+# ~/.claude/runcat-usage.json を書き出す)。実体は上流サンプルのまま置き、
+# 差分追従しやすくする: https://github.com/runcat-dev/RunCatNeo/tree/main/docs/samples/claude-code
 - name: Define Claude global config files
   ansible.builtin.set_fact:
     claude_config_files:
       - CLAUDE.md
       - settings.json
+      - runcat-statusline.py
 
 - name: Create ~/.claude directory
   ansible.builtin.file:


### PR DESCRIPTION
## 目的

RunCat Neo (menubar アプリ) の Custom Metrics カードに Claude Code のセッション状況
(モデル・コンテキスト使用率・5h / 7d のレート制限) を表示する。
上流サンプル [runcat-dev/RunCatNeo docs/samples/claude-code](https://github.com/runcat-dev/RunCatNeo/tree/main/docs/samples/claude-code) は
「スクリプトを `~/.claude/` へコピーする」手順だが、他のグローバル設定と同じく
setup リポジトリで管理して symlink 配布に乗せる。

## 変更点

- `claude/runcat-statusline.py`: 上流サンプルを**改変なし**で配置 (上流更新との差分追従のため)。
  statusLine 実行のたびに `~/.claude/runcat-usage.json` へ Custom Metrics 形式のスナップショットを書き、
  stdout にモデル名を出す
- `tasks/claude.yml`: `claude_config_files` に追加し `~/.claude/runcat-statusline.py` へ symlink
  (既存の実体ファイルは既存タスクどおり `.bak-<date>` へ退避される)
- `claude/settings.json`: `statusLine` に `~/.claude/runcat-statusline.py` を登録

## 確認方法

- サンプル payload を stdin に流して出力を確認 (`metricsBarValue` / `normalizedValue` / stdout のモデル名)

  ```bash
  echo '{"model":{"display_name":"Opus 4.8"},"context_window":{"used_percentage":42.5},"rate_limits":{"five_hour":{"used_percentage":3},"seven_day":{"used_percentage":11}}}' | RUNCAT_OUT_FILE=/tmp/out.json ./claude/runcat-statusline.py
  ```

- 空 payload (`printf '{}'`) でも例外を出さず Model 行のみで出力されることを確認
- `python3 -m json.tool claude/settings.json` / `ansible-playbook --syntax-check playbook_sillicon_mac.yml`
- git 上で実行ビット (100755) が保たれていることを確認

## マージ後の手順

1. `ansible-playbook playbook_sillicon_mac.yml --tags claude` を `/Users/so/.setup` で実行し symlink 化
2. RunCat Neo の **Settings → Metrics → Custom Metrics → Add Custom Metrics Source** で
   `~/.claude/runcat-usage.json` を選択 (GUI 操作のため要手動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)