### PR TITLE
feat(claude): RunCat Neo カードに statusLine の全メトリクスを表示

### DIFF
--- a/claude/runcat-statusline.py
+++ b/claude/runcat-statusline.py
@@ -1,21 +1,34 @@
 #!/usr/bin/env python3
 """
-RunCat Neo — Claude Code statusLine sample.
+RunCat Neo — Claude Code statusLine 連携。
 
-Writes ~/.claude/runcat-usage.json shaped like:
+上流サンプル (runcat-dev/RunCatNeo docs/samples/claude-code/runcat-statusline.py)
+をベースに、statusLine が渡す JSON のうち意味のある値をすべて出すよう拡張したもの。
 
-    {
-      "title": "Claude Code",
-      "symbol": "staroflife",
-      "metricsBarValue": "67%",
-      "metrics": [
-        {"title": "Model",   "formattedValue": "Opus 4.7"},
-        {"title": "Context", "formattedValue": "67%", "normalizedValue": 0.67},
-        {"title": "5h",      "formattedValue": "3%",  "normalizedValue": 0.03},
-        {"title": "7d",      "formattedValue": "3%",  "normalizedValue": 0.03}
-      ],
-      "lastUpdatedDate": "2026-06-07T05:55:36Z"
-    }
+Claude Code は毎ターン statusLine コマンドの stdin へセッション情報の JSON を渡す
+(仕様: https://code.claude.com/docs/en/statusline)。本スクリプトはそれを RunCat Neo の
+Custom Metrics 形式 (仕様: https://github.com/runcat-dev/RunCatNeo/blob/main/docs/CustomMetricsSchema.md)
+へ変換して ~/.claude/runcat-usage.json へ原子的に書き出し、stdout にはモデル名を出す。
+
+出力される行 (値が取れないフィールドの行は出さない):
+
+    Model    Opus 4.8 · xhigh · think · fast   model / effort / thinking / fast_mode
+    Context  31% · 62.5k/200k                  context_window (バー付き)
+    5h       23.5% · 2h41m left                rate_limits.five_hour (バー付き)
+    7d       41.2% · 3d4h left                 rate_limits.seven_day (バー付き)
+    Cost     $0.42                             cost.total_cost_usd
+    Elapsed  45m · API 2m18s                   cost.total_duration_ms / total_api_duration_ms
+    Edits    +156 / -23                        cost.total_lines_{added,removed}
+    Project  claude-code · feature-xyz         workspace.repo.name (または project_dir) / worktree
+    Session  my-session                        session_name
+    Agent    security-reviewer                 agent.name
+    PR       #1234 · pending                   pr.number / pr.review_state
+
+意図的に出していないもの: session_id・prompt_id・transcript_path・cwd (カード向きでない ID / パス)、
+version・output_style.name・vim.mode (常時見る価値が薄い)、exceeds_200k_tokens
+(Context 行と重複。1M コンテキストのモデルでのみ差が出る)。
+
+環境変数 RUNCAT_OUT_FILE で出力先を上書きできる (既定: ~/.claude/runcat-usage.json)。
 """
 
 import json
@@ -28,10 +41,70 @@ from pathlib import Path
 OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
 
 
-def pct(title, value):
+def num(value):
+    """数値として扱える場合だけ float を返す (bool は数値扱いしない)。"""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def obj(payload, *keys):
+    """ネストした dict を辿る。途中が dict でなければ空 dict。"""
+    current = payload
+    for key in keys:
+        if not isinstance(current, dict):
+            return {}
+        current = current.get(key)
+    return current if isinstance(current, dict) else {}
+
+
+def row(title, formatted, normalized=None):
+    if not formatted:
+        return None
+    metric = {"title": title, "formattedValue": str(formatted)}
+    if normalized is not None:
+        metric["normalizedValue"] = round(min(max(normalized, 0.0), 1.0), 4)
+    return metric
+
+
+def fmt_tokens(value):
+    """トークン数を 62.7k / 200k / 1.2M の形へ (末尾の .0 は落とす)。"""
     if value is None:
         return None
-    return {"title": title, "formattedValue": f"{value:g}%", "normalizedValue": round(value / 100, 4)}
+    for unit, scale in (("M", 1_000_000), ("k", 1_000)):
+        if value >= scale:
+            return f"{value / scale:.1f}".rstrip("0").rstrip(".") + unit
+    return f"{value:.0f}"
+
+
+def fmt_duration(seconds):
+    """残り時間・経過時間を 3d4h / 2h41m / 45m / 12s の形へ。"""
+    if seconds is None or seconds < 0:
+        return None
+    seconds = int(seconds)
+    days, rest = divmod(seconds, 86400)
+    hours, rest = divmod(rest, 3600)
+    minutes, secs = divmod(rest, 60)
+    if days:
+        return f"{days}d{hours}h"
+    if hours:
+        return f"{hours}h{minutes:02d}m"
+    if minutes:
+        return f"{minutes}m"
+    return f"{secs}s"
+
+
+def rate_limit_row(title, window, now_epoch):
+    """レート制限の行。使用率にリセットまでの残り時間を添える。"""
+    used = num(window.get("used_percentage"))
+    if used is None:
+        return None
+    text = f"{used:g}%"
+    resets_at = num(window.get("resets_at"))
+    left = fmt_duration(resets_at - now_epoch) if resets_at is not None else None
+    if left:
+        text += f" · {left} left"
+    return row(title, text, used / 100)
 
 
 try:
@@ -41,25 +114,82 @@ try:
 except Exception:
     payload = {}
 
-model = (payload.get("model") or {}).get("display_name") or "Claude Code"
-ctx = (payload.get("context_window") or {}).get("used_percentage")
-rate_limits = payload.get("rate_limits") or {}
-five = (rate_limits.get("five_hour") or {}).get("used_percentage")
-seven = (rate_limits.get("seven_day") or {}).get("used_percentage")
+now = datetime.now(timezone.utc)
+
+# Model: モデル名に effort / extended thinking / fast mode のマーカーを添える
+model_name = obj(payload, "model").get("display_name") or "Claude Code"
+parts = [str(model_name)]
+if obj(payload, "effort").get("level"):
+    parts.append(str(obj(payload, "effort")["level"]))
+if obj(payload, "thinking").get("enabled") is True:
+    parts.append("think")
+if payload.get("fast_mode") is True:
+    parts.append("fast")
+model_text = " · ".join(parts)
+
+# Context: 使用率にトークン数 (現在/上限) を添える
+context = obj(payload, "context_window")
+ctx_pct = num(context.get("used_percentage"))
+ctx_text = f"{ctx_pct:g}%" if ctx_pct is not None else None
+in_tokens = num(context.get("total_input_tokens"))
+out_tokens = num(context.get("total_output_tokens"))
+used_tokens = (in_tokens or 0) + (out_tokens or 0) if (in_tokens is not None or out_tokens is not None) else None
+size_tokens = num(context.get("context_window_size"))
+if ctx_text and used_tokens is not None and size_tokens:
+    ctx_text += f" · {fmt_tokens(used_tokens)}/{fmt_tokens(size_tokens)}"
+
+# Cost / Elapsed / Edits
+cost = obj(payload, "cost")
+cost_usd = num(cost.get("total_cost_usd"))
+cost_text = f"${cost_usd:,.2f}" if cost_usd is not None else None
+
+total_ms = num(cost.get("total_duration_ms"))
+api_ms = num(cost.get("total_api_duration_ms"))
+elapsed = fmt_duration(total_ms / 1000) if total_ms is not None else None
+api_elapsed = fmt_duration(api_ms / 1000) if api_ms is not None else None
+if elapsed and api_elapsed:
+    elapsed = f"{elapsed} · API {api_elapsed}"
+
+added = num(cost.get("total_lines_added"))
+removed = num(cost.get("total_lines_removed"))
+edits_text = f"+{added:.0f} / -{removed:.0f}" if added is not None and removed is not None else None
+
+# Project: リポジトリ名 (なければ起動ディレクトリ名) に worktree 名を添える。
+# 複数セッションが同じ JSON を上書きするため、どのセッションの値かを見分ける手掛かりになる
+workspace = obj(payload, "workspace")
+project = obj(workspace, "repo").get("name")
+if not project and workspace.get("project_dir"):
+    project = os.path.basename(str(workspace["project_dir"]).rstrip("/"))
+worktree = workspace.get("git_worktree") or obj(payload, "worktree").get("name")
+project_text = f"{project} · {worktree}" if project and worktree else (project or worktree)
+
+# PR: 番号にレビュー状態を添える
+pr = obj(payload, "pr")
+pr_text = f"#{pr['number']}" if pr.get("number") is not None else None
+if pr_text and pr.get("review_state"):
+    pr_text += f" · {pr['review_state']}"
 
 snapshot = {
     "title": "Claude Code",
     "symbol": "staroflife",
     "metrics": [m for m in [
-        {"title": "Model", "formattedValue": model},
-        pct("Context", ctx),
-        pct("5h", five),
-        pct("7d", seven),
+        row("Model", model_text),
+        row("Context", ctx_text, ctx_pct / 100 if ctx_pct is not None else None),
+        rate_limit_row("5h", obj(payload, "rate_limits", "five_hour"), now.timestamp()),
+        rate_limit_row("7d", obj(payload, "rate_limits", "seven_day"), now.timestamp()),
+        row("Cost", cost_text),
+        row("Elapsed", elapsed),
+        row("Edits", edits_text),
+        row("Project", project_text),
+        row("Session", payload.get("session_name")),
+        row("Agent", obj(payload, "agent").get("name")),
+        row("PR", pr_text),
     ] if m is not None],
-    "lastUpdatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "lastUpdatedDate": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
 }
-if ctx is not None:
-    snapshot["metricsBarValue"] = f"{ctx:g}%"
+if ctx_pct is not None:
+    # メニューバーは幅が狭く長い文字列は切られるため、整数へ丸めて出す
+    snapshot["metricsBarValue"] = f"{ctx_pct:.0f}%"
 
 OUT.parent.mkdir(parents=True, exist_ok=True)
 fd, tmp = tempfile.mkstemp(prefix=".runcat-", dir=str(OUT.parent))
@@ -67,4 +197,4 @@ with os.fdopen(fd, "w", encoding="utf-8") as f:
     json.dump(snapshot, f, ensure_ascii=False)
 os.replace(tmp, OUT)
 
-print(model)
+print(model_name)

--- a/claude/tests/runcat_statusline_test.py
+++ b/claude/tests/runcat_statusline_test.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""claude/runcat-statusline.py のテスト。
+
+スクリプトは import 時に stdin を読んで走り切る作りなので、実際の契約
+(stdin の JSON → 出力ファイルの JSON + stdout) をサブプロセス経由で検証する。
+
+    python3 claude/tests/runcat_statusline_test.py
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "runcat-statusline.py"
+
+
+class RunCatStatusLineTestCase(unittest.TestCase):
+    def run_script(self, stdin_text):
+        """stdin を流してスクリプトを実行し、(スナップショット, stdout) を返す。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "usage.json"
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                input=stdin_text,
+                capture_output=True,
+                text=True,
+                env={"RUNCAT_OUT_FILE": str(out), "PATH": "/usr/bin:/bin", "HOME": tmpdir},
+                check=True,
+            )
+            return json.loads(out.read_text(encoding="utf-8")), proc.stdout.strip()
+
+    def rows(self, snapshot):
+        return {m["title"]: m for m in snapshot["metrics"]}
+
+    def test_full_payload_renders_every_row(self):
+        now = int(time.time())
+        payload = {
+            "model": {"id": "claude-opus-4-8", "display_name": "Opus 4.8"},
+            "session_name": "runcat-metrics",
+            "workspace": {
+                "project_dir": "/Users/so/.setup",
+                "git_worktree": "feature-xyz",
+                "repo": {"host": "github.com", "owner": "shinyaoguri", "name": "setup"},
+            },
+            "cost": {
+                "total_cost_usd": 12.3456,
+                "total_duration_ms": 4_500_000,
+                "total_api_duration_ms": 138_000,
+                "total_lines_added": 156,
+                "total_lines_removed": 23,
+            },
+            "context_window": {
+                "total_input_tokens": 61_500,
+                "total_output_tokens": 1_200,
+                "context_window_size": 200_000,
+                "used_percentage": 31.35,
+            },
+            "fast_mode": True,
+            "effort": {"level": "xhigh"},
+            "thinking": {"enabled": True},
+            "rate_limits": {
+                # 端数 30 秒を足して、テスト実行中の経過で分が繰り下がらないようにする
+                "five_hour": {"used_percentage": 23.5, "resets_at": now + 9_660 + 30},
+                "seven_day": {"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
+            },
+            "agent": {"name": "security-reviewer"},
+            "pr": {"number": 1234, "review_state": "pending"},
+        }
+        snapshot, stdout = self.run_script(json.dumps(payload))
+        rows = self.rows(snapshot)
+
+        self.assertEqual(stdout, "Opus 4.8")
+        self.assertEqual(snapshot["title"], "Claude Code")
+        self.assertEqual(snapshot["metricsBarValue"], "31%")  # メニューバーは整数へ丸める
+        self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · xhigh · think · fast")
+        self.assertEqual(rows["Context"]["formattedValue"], "31.35% · 62.7k/200k")
+        self.assertAlmostEqual(rows["Context"]["normalizedValue"], 0.3135)
+        self.assertEqual(rows["5h"]["formattedValue"], "23.5% · 2h41m left")
+        self.assertEqual(rows["7d"]["formattedValue"], "41.2% · 3d4h left")
+        self.assertEqual(rows["Cost"]["formattedValue"], "$12.35")
+        self.assertEqual(rows["Elapsed"]["formattedValue"], "1h15m · API 2m")
+        self.assertEqual(rows["Edits"]["formattedValue"], "+156 / -23")
+        self.assertEqual(rows["Project"]["formattedValue"], "setup · feature-xyz")
+        self.assertEqual(rows["Session"]["formattedValue"], "runcat-metrics")
+        self.assertEqual(rows["Agent"]["formattedValue"], "security-reviewer")
+        self.assertEqual(rows["PR"]["formattedValue"], "#1234 · pending")
+        # 進捗バーは割合を持つ行にだけ付く
+        self.assertNotIn("normalizedValue", rows["Model"])
+        self.assertNotIn("normalizedValue", rows["Cost"])
+
+    def test_empty_payload_falls_back_to_model_row_only(self):
+        snapshot, stdout = self.run_script("{}")
+        self.assertEqual(stdout, "Claude Code")
+        self.assertEqual([m["title"] for m in snapshot["metrics"]], ["Model"])
+        self.assertNotIn("metricsBarValue", snapshot)
+
+    def test_malformed_stdin_does_not_crash(self):
+        for stdin_text in ("", "not json at all", "[1,2,3]", "null"):
+            with self.subTest(stdin=stdin_text):
+                snapshot, stdout = self.run_script(stdin_text)
+                self.assertEqual(stdout, "Claude Code")
+                self.assertEqual(self.rows(snapshot)["Model"]["formattedValue"], "Claude Code")
+
+    def test_wrong_types_are_ignored_instead_of_rendered(self):
+        payload = {
+            "model": "Opus 4.8",  # dict でなく文字列
+            "context_window": {"used_percentage": None, "total_input_tokens": "x"},
+            "cost": {"total_cost_usd": True},  # bool は数値扱いしない
+            "rate_limits": None,
+            "effort": {"level": None},
+            "fast_mode": "yes",  # true でなければマーカーを出さない
+        }
+        snapshot, _ = self.run_script(json.dumps(payload))
+        self.assertEqual([m["title"] for m in snapshot["metrics"]], ["Model"])
+        self.assertEqual(self.rows(snapshot)["Model"]["formattedValue"], "Claude Code")
+
+    def test_expired_reset_and_over_limit_percentage(self):
+        payload = {"rate_limits": {"five_hour": {"used_percentage": 150, "resets_at": 1}}}
+        snapshot, _ = self.run_script(json.dumps(payload))
+        row = self.rows(snapshot)["5h"]
+        self.assertEqual(row["formattedValue"], "150%")  # 過去のリセット時刻は添えない
+        self.assertEqual(row["normalizedValue"], 1.0)  # バーは [0,1] にクランプ
+
+    def test_million_token_context_window(self):
+        payload = {"context_window": {
+            "used_percentage": 8.4, "total_input_tokens": 83_000,
+            "total_output_tokens": 1_500, "context_window_size": 1_000_000,
+        }}
+        snapshot, _ = self.run_script(json.dumps(payload))
+        self.assertEqual(self.rows(snapshot)["Context"]["formattedValue"], "8.4% · 84.5k/1M")
+        self.assertEqual(snapshot["metricsBarValue"], "8%")
+
+    def test_project_falls_back_to_directory_name(self):
+        payload = {"workspace": {"project_dir": "/Users/so/foo/"}, "worktree": {"name": "my-feature"}}
+        snapshot, _ = self.run_script(json.dumps(payload))
+        self.assertEqual(self.rows(snapshot)["Project"]["formattedValue"], "foo · my-feature")
+
+    def test_zero_values_are_rendered_not_dropped(self):
+        payload = {"cost": {"total_cost_usd": 0, "total_lines_added": 0, "total_lines_removed": 0},
+                   "context_window": {"used_percentage": 0}}
+        snapshot, _ = self.run_script(json.dumps(payload))
+        rows = self.rows(snapshot)
+        self.assertEqual(rows["Cost"]["formattedValue"], "$0.00")
+        self.assertEqual(rows["Edits"]["formattedValue"], "+0 / -0")
+        self.assertEqual(rows["Context"]["formattedValue"], "0%")
+        self.assertEqual(snapshot["metricsBarValue"], "0%")
+
+    def test_snapshot_is_valid_custom_metrics_schema(self):
+        snapshot, _ = self.run_script('{"model": {"display_name": "Opus 4.8"}}')
+        self.assertIsInstance(snapshot["title"], str)
+        self.assertIsInstance(snapshot["symbol"], str)
+        self.assertIsInstance(snapshot["metrics"], list)
+        # lastUpdatedDate は RunCat が要求する ISO 8601 (UTC) 形式
+        self.assertRegex(snapshot["lastUpdatedDate"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+        for metric in snapshot["metrics"]:
+            self.assertIsInstance(metric["title"], str)
+            self.assertIsInstance(metric["formattedValue"], str)
+            if "normalizedValue" in metric:
+                self.assertGreaterEqual(metric["normalizedValue"], 0.0)
+                self.assertLessEqual(metric["normalizedValue"], 1.0)
+
+    def test_output_file_is_replaced_atomically(self):
+        """一時ファイルを残さず os.replace で置き換える (RunCat が半端な内容を読まないため)。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "usage.json"
+            out.write_text("stale", encoding="utf-8")
+            subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                input='{"model": {"display_name": "Opus 4.8"}}',
+                capture_output=True, text=True, check=True,
+                env={"RUNCAT_OUT_FILE": str(out), "PATH": "/usr/bin:/bin", "HOME": tmpdir},
+            )
+            self.assertEqual(json.loads(out.read_text(encoding="utf-8"))["title"], "Claude Code")
+            self.assertEqual([p.name for p in Path(tmpdir).iterdir()], ["usage.json"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -3,8 +3,9 @@
 # 全プロジェクト共通スキル (claude/skills/*) のリンク
 
 # runcat-statusline.py は RunCat Neo の Custom Metrics 連携 (statusLine から
-# ~/.claude/runcat-usage.json を書き出す)。実体は上流サンプルのまま置き、
-# 差分追従しやすくする: https://github.com/runcat-dev/RunCatNeo/tree/main/docs/samples/claude-code
+# ~/.claude/runcat-usage.json を書き出す)。上流サンプルをベースに全メトリクスを出すよう拡張:
+# https://github.com/runcat-dev/RunCatNeo/tree/main/docs/samples/claude-code
+# テストは claude/tests/runcat_statusline_test.py (python3 で直接実行)
 - name: Define Claude global config files
   ansible.builtin.set_fact:
     claude_config_files:


### PR DESCRIPTION
## 目的

#22 で入れた上流サンプルは、Claude Code が statusLine に渡す約 35 フィールドのうち **4 つ**
(`model.display_name` / `context_window.used_percentage` / `rate_limits.{five_hour,seven_day}.used_percentage`)
しか使っていなかった。[Custom Metrics 仕様](https://github.com/runcat-dev/RunCatNeo/blob/main/docs/CustomMetricsSchema.md)
にカード行数の制約はないので、[statusLine が渡す値](https://code.claude.com/docs/en/statusline)のうち
意味のあるものをすべて表示する。

## 変更点

`claude/runcat-statusline.py` の出力行 (値が取れないフィールドの行は出さない):

| 行 | 例 | 由来 |
| --- | --- | --- |
| Model | `Opus 4.8 · xhigh · think · fast` | `model` + `effort.level` / `thinking.enabled` / `fast_mode` |
| Context | `31.35% · 62.7k/200k` | `context_window` (バー付き) |
| 5h / 7d | `23.5% · 2h41m left` | `rate_limits.*.used_percentage` + `resets_at` (バー付き) |
| Cost | `$12.35` | `cost.total_cost_usd` |
| Elapsed | `1h15m · API 2m` | `cost.total_duration_ms` / `total_api_duration_ms` |
| Edits | `+156 / -23` | `cost.total_lines_{added,removed}` |
| Project | `setup · feature-xyz` | `workspace.repo.name` (無ければ `project_dir` 名) + worktree |
| Session / Agent / PR | `runcat-metrics` / `security-reviewer` / `#1234 · pending` | `session_name` / `agent.name` / `pr` |

Project・Session 行は、**複数セッションが同じ `~/.claude/runcat-usage.json` を上書きする**
(最後に書いたセッションが勝つ) ため、いま出ている値がどのセッションのものか見分ける手掛かりになる。

意図的に出さないもの: `session_id` / `prompt_id` / `transcript_path` / `cwd` (カード向きでない ID・パス)、
`version` / `output_style.name` / `vim.mode` (常時見る価値が薄い)、`exceeds_200k_tokens`
(Context 行と重複し、1M コンテキストのモデルでしか差が出ない)。

メニューバーの `metricsBarValue` は幅が狭く truncate されるため整数へ丸める (`31.35%` → `31%`)。

## テスト

`claude/tests/runcat_statusline_test.py` を追加 (標準ライブラリのみ、依存追加なし)。
スクリプトは import 時に stdin を読んで走り切る作りなので、サブプロセス経由で実契約
(stdin の JSON → 出力ファイルの JSON + stdout) を検証する。

```bash
python3 claude/tests/runcat_statusline_test.py
```

- 正常系: 全フィールドを含む payload で 11 行すべてと `metricsBarValue`・バーの有無を検証
- 失敗系・境界値: 空 payload / 壊れた JSON / 配列 / `null` / 型違い (bool・文字列) /
  使用率 100 超のクランプ / 期限切れ `resets_at` / 1M コンテキスト / 0 値 / 一時ファイルを残さない原子的置き換え
- 実装を 6 通り (丸め・クランプ・過去時刻の除外・bool 判定・トークン表記・`os.replace`) に
  壊して該当テストが赤くなることを確認済み → 10 tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)