### PR TITLE
feat(claude): RunCat のカードでレート制限を主役にする

### DIFF
--- a/claude/runcat-metrics.py
+++ b/claude/runcat-metrics.py
@@ -25,8 +25,8 @@ RunCat Neo の Custom Metrics 形式
     行       例                                 statusLine  hook
     Model    Opus 4.8 · xhigh · think · fast        ◯    ◯ (think/fast は無し)
     Context  31% · 62.5k/200k                       ◯    ◯ (上限は 200k 固定)
-    5h / 7d  23.5% · 2h41m left                     ◯    ✗ (hook 入力に無い)
-    Cost     $0.42                                  ◯    ✗ (同上。トークン単価は持たない)
+    5h / 7d  23.5% · 2h41m left                     ◯    △ (statusLine の控えを使う)
+    Cost     $0.42                                  ◯    ✗ (hook 入力に無い。トークン単価も持たない)
     Elapsed  45m · API 2m18s                        ◯    ◯ (API 時間は無し)
     Edits    +156 / -23                             ◯    ✗
     Project  setup · feature-xyz                    ◯    ◯ (worktree 名でなくブランチ名)
@@ -34,11 +34,20 @@ RunCat Neo の Custom Metrics 形式
     Agent    security-reviewer                      ◯    ✗
     PR       #1234 · pending                        ◯    ◯ (レビュー状態は無し)
 
+メニューバーへ出す値 (metricsBarValue) は週間制限の使用率。
+
+レート制限は hook 入力にも transcript にも無いため、statusLine モードで取れた値を
+控え (RATE_LIMITS_CACHE)、hook モードではリセット時刻を過ぎるまでそれを使う。
+控えは最後に取れた時点の値で実際はそれ以上なので、下限として ≥ を頭に付けて出す。
+モデル別の週間制限 (Opus / Sonnet / Fable) は Claude Code が statusLine へ渡すのが
+five_hour と seven_day だけのため出せない (2.1.205 時点)。
+
 意図的に出していないもの: session_id・prompt_id・transcript_path・cwd (カード向きでない
 ID / パス)、version・output_style.name・vim.mode (常時見る価値が薄い)、
 exceeds_200k_tokens (Context 行と重複。1M コンテキストのモデルでのみ差が出る)。
 
 環境変数 RUNCAT_OUT_FILE で出力先を上書きできる (既定: ~/.claude/runcat-usage.json)。
+レート制限の控えは同じディレクトリの runcat-rate-limits.json に置く。
 """
 
 import json
@@ -49,6 +58,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
+
+# statusLine で取れたレート制限の控え (hook モードから読む)
+RATE_LIMITS_CACHE = OUT.parent / "runcat-rate-limits.json"
 
 # hook モードでは文脈上限が入力に無いため既定値を使う (1M コンテキストのモデルでは過大に出る)
 DEFAULT_CONTEXT_WINDOW = 200_000
@@ -126,16 +138,14 @@ def fmt_model_id(model_id):
 
 
 def context_row(used_tokens, size_tokens, used_pct=None):
-    """Context 行と、メニューバーへ出す文字列を返す。"""
     if used_pct is None:
         if not used_tokens or not size_tokens:
-            return None, None
+            return None
         used_pct = round(used_tokens / size_tokens * 100, 1)
     text = f"{used_pct:g}%"
     if used_tokens is not None and size_tokens:
         text += f" · {fmt_tokens(used_tokens)}/{fmt_tokens(size_tokens)}"
-    # メニューバーは幅が狭く長い文字列は切られるため、整数へ丸めて出す
-    return row("Context", text, used_pct / 100), f"{used_pct:.0f}%"
+    return row("Context", text, used_pct / 100)
 
 
 def snapshot(metrics, bar_value=None):
@@ -150,28 +160,69 @@ def snapshot(metrics, bar_value=None):
     return result
 
 
-def write_snapshot(data):
-    """RunCat が半端な内容を読まないよう、一時ファイル経由で原子的に置き換える。"""
-    OUT.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=".runcat-", dir=str(OUT.parent))
+def write_json(path, data):
+    """読み手が半端な内容を読まないよう、一時ファイル経由で原子的に置き換える。"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".runcat-", dir=str(path.parent))
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False)
-    os.replace(tmp, OUT)
+    os.replace(tmp, path)
 
 
-# --- statusLine モード ---------------------------------------------------------
+# --- レート制限 ----------------------------------------------------------------
 
-def rate_limit_row(title, window, now_epoch):
-    """レート制限の行。使用率にリセットまでの残り時間を添える。"""
+def rate_limit_row(title, window, now_epoch, stale=False):
+    """レート制限の行。使用率にリセットまでの残り時間を添える。
+
+    stale は控えから読んだ値。以後も使用率は上がる一方なので下限として ≥ を付ける。
+    """
     used = num(window.get("used_percentage"))
     if used is None:
         return None
-    text = f"{used:g}%"
+    text = f"{'≥' if stale else ''}{used:g}%"
     resets_at = num(window.get("resets_at"))
     left = fmt_duration(resets_at - now_epoch) if resets_at is not None else None
     if left:
         text += f" · {left} left"
     return row(title, text, used / 100)
+
+
+def fmt_bar_value(window, stale=False):
+    """メニューバーは幅が狭く長い文字列は切られるため、整数へ丸めて出す。"""
+    used = num(window.get("used_percentage"))
+    if used is None:
+        return None
+    return f"{'≥' if stale else ''}{used:.0f}%"
+
+
+def save_rate_limits(windows):
+    """statusLine で取れたレート制限を hook モード用に控える。"""
+    kept = {}
+    for key, window in windows.items():
+        used = num(window.get("used_percentage"))
+        resets_at = num(window.get("resets_at"))
+        if used is None or resets_at is None:
+            continue  # リセット時刻が無い値は古さを判定できないので控えない
+        kept[key] = {"used_percentage": used, "resets_at": resets_at}
+    if kept:
+        write_json(RATE_LIMITS_CACHE, kept)
+
+
+def load_rate_limits(now_epoch):
+    """控えのうち、まだリセットされていないウィンドウだけ返す。"""
+    try:
+        cached = json.loads(RATE_LIMITS_CACHE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    if not isinstance(cached, dict):
+        return {}
+    return {
+        key: window for key, window in cached.items()
+        if isinstance(window, dict) and (num(window.get("resets_at")) or 0) > now_epoch
+    }
+
+
+# --- statusLine モード ---------------------------------------------------------
 
 
 def from_statusline(payload):
@@ -193,9 +244,15 @@ def from_statusline(payload):
     in_tokens = num(context.get("total_input_tokens"))
     out_tokens = num(context.get("total_output_tokens"))
     used_tokens = (in_tokens or 0) + (out_tokens or 0) if (in_tokens is not None or out_tokens is not None) else None
-    ctx_row, bar_value = (None, None)
+    ctx_row = None
     if ctx_pct is not None:
-        ctx_row, bar_value = context_row(used_tokens, num(context.get("context_window_size")), ctx_pct)
+        ctx_row = context_row(used_tokens, num(context.get("context_window_size")), ctx_pct)
+
+    # レート制限: hook モード (デスクトップアプリ) では取れないのでここで控えておく
+    five_hour = obj(payload, "rate_limits", "five_hour")
+    seven_day = obj(payload, "rate_limits", "seven_day")
+    if five_hour or seven_day:
+        save_rate_limits({"five_hour": five_hour, "seven_day": seven_day})
 
     # Cost / Elapsed / Edits
     cost = obj(payload, "cost")
@@ -226,8 +283,8 @@ def from_statusline(payload):
     metrics = [
         row("Model", " · ".join(parts)),
         ctx_row,
-        rate_limit_row("5h", obj(payload, "rate_limits", "five_hour"), now_epoch),
-        rate_limit_row("7d", obj(payload, "rate_limits", "seven_day"), now_epoch),
+        rate_limit_row("5h", five_hour, now_epoch),
+        rate_limit_row("7d", seven_day, now_epoch),
         row("Cost", f"${cost_usd:,.2f}" if cost_usd is not None else None),
         row("Elapsed", elapsed),
         row("Edits", f"+{added:.0f} / -{removed:.0f}" if added is not None and removed is not None else None),
@@ -236,7 +293,7 @@ def from_statusline(payload):
         row("Agent", obj(payload, "agent").get("name")),
         row("PR", pr_text),
     ]
-    return snapshot(metrics, bar_value), str(model_name)
+    return snapshot(metrics, fmt_bar_value(seven_day)), str(model_name)
 
 
 # --- hook モード ---------------------------------------------------------------
@@ -281,6 +338,7 @@ def parse_ts(value):
 
 
 def from_transcript(path):
+    now_epoch = datetime.now(timezone.utc).timestamp()
     entries = read_transcript(path)
     assistants = [e for e in entries if e.get("type") == "assistant" and not e.get("isSidechain")]
     last = assistants[-1] if assistants else {}
@@ -297,7 +355,11 @@ def from_transcript(path):
         num(usage.get(k)) or 0
         for k in ("input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens", "output_tokens")
     ) or None
-    ctx_row, bar_value = context_row(used_tokens, DEFAULT_CONTEXT_WINDOW)
+    ctx_row = context_row(used_tokens, DEFAULT_CONTEXT_WINDOW)
+
+    # レート制限: hook 入力には無いので statusLine モードの控えを使う
+    cached_limits = load_rate_limits(now_epoch)
+    seven_day = cached_limits.get("seven_day", {})
 
     # Elapsed: transcript の最初と最後のエントリの時刻差
     start = parse_ts(entries[0].get("timestamp")) if entries else None
@@ -318,12 +380,14 @@ def from_transcript(path):
     metrics = [
         row("Model", " · ".join(parts)),
         ctx_row,
+        rate_limit_row("5h", cached_limits.get("five_hour", {}), now_epoch, stale=True),
+        rate_limit_row("7d", seven_day, now_epoch, stale=True),
         row("Elapsed", elapsed),
         row("Project", f"{project} · {branch}" if project and branch else (project or branch)),
         row("Session", title),
         row("PR", f"#{pr_number}" if pr_number is not None else None),
     ]
-    return snapshot(metrics, bar_value)
+    return snapshot(metrics, fmt_bar_value(seven_day, stale=True))
 
 
 # --- エントリポイント -----------------------------------------------------------
@@ -339,13 +403,13 @@ def main():
     if payload.get("hook_event_name"):
         # hook を止めないよう、失敗しても黙って終了する
         try:
-            write_snapshot(from_transcript(payload["transcript_path"]))
+            write_json(OUT, from_transcript(payload["transcript_path"]))
         except Exception:
             pass
         return
 
     data, model_name = from_statusline(payload)
-    write_snapshot(data)
+    write_json(OUT, data)
     print(model_name)
 
 

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -19,22 +19,65 @@ SCRIPT = Path(__file__).resolve().parent.parent / "runcat-metrics.py"
 
 
 class ScriptTestCase(unittest.TestCase):
-    def run_script(self, stdin_text):
-        """stdin を流してスクリプトを実行し、(スナップショット, stdout) を返す。"""
+    def run_script(self, stdin_text, workdir=None):
+        """stdin を流してスクリプトを実行し、(スナップショット, stdout) を返す。
+
+        workdir を渡すと出力先を共有できる (レート制限の控えを跨ぐ実行の検証用)。
+        """
+        if workdir is not None:
+            return self.run_script_in(stdin_text, Path(workdir))
         with tempfile.TemporaryDirectory() as tmpdir:
-            out = Path(tmpdir) / "usage.json"
-            proc = subprocess.run(
-                [sys.executable, str(SCRIPT)],
-                input=stdin_text,
-                capture_output=True,
-                text=True,
-                env={"RUNCAT_OUT_FILE": str(out), "PATH": "/usr/bin:/bin", "HOME": tmpdir},
-                check=True,
-            )
-            return json.loads(out.read_text(encoding="utf-8")), proc.stdout.strip()
+            return self.run_script_in(stdin_text, Path(tmpdir))
+
+    def run_script_in(self, stdin_text, workdir):
+        out = workdir / "usage.json"
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            env={"RUNCAT_OUT_FILE": str(out), "PATH": "/usr/bin:/bin", "HOME": str(workdir)},
+            check=True,
+        )
+        return json.loads(out.read_text(encoding="utf-8")), proc.stdout.strip()
 
     def rows(self, snapshot):
         return {m["title"]: m for m in snapshot["metrics"]}
+
+    def run_hook(self, entries, event="Stop", workdir=None):
+        """transcript JSONL を作り、hook 入力を流してスナップショットを返す。"""
+        if workdir is None:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                return self.run_hook(entries, event, Path(tmpdir))
+        workdir = Path(workdir)
+        transcript = workdir / "transcript.jsonl"
+        transcript.write_text(
+            "".join(json.dumps(e, ensure_ascii=False) + "\n" for e in entries), encoding="utf-8"
+        )
+        snapshot, stdout = self.run_script(json.dumps({
+            "hook_event_name": event,
+            "session_id": "abc123",
+            "transcript_path": str(transcript),
+            "cwd": "/Users/so/.setup",
+        }), workdir=workdir)
+        # hook の stdout は会話へ混ざり得るので何も出さない
+        self.assertEqual(stdout, "")
+        return snapshot
+
+    def assistant_entry(self, **overrides):
+        entry = {
+            "type": "assistant",
+            "timestamp": "2026-07-23T09:19:24.246Z",
+            "cwd": "/Users/so/.setup",
+            "gitBranch": "feat/runcat-metrics-hook",
+            "effort": "high",
+            "message": {"model": "claude-opus-4-8", "usage": {
+                "input_tokens": 2, "cache_creation_input_tokens": 1970,
+                "cache_read_input_tokens": 138413, "output_tokens": 2163,
+            }},
+        }
+        entry.update(overrides)
+        return entry
 
 
 class StatusLineModeTest(ScriptTestCase):
@@ -79,7 +122,8 @@ class StatusLineModeTest(ScriptTestCase):
 
         self.assertEqual(stdout, "Opus 4.8")
         self.assertEqual(snapshot["title"], "Claude Code")
-        self.assertEqual(snapshot["metricsBarValue"], "31%")  # メニューバーは整数へ丸める
+        # メニューバーへ出すのは週間制限の使用率 (整数へ丸める)
+        self.assertEqual(snapshot["metricsBarValue"], "41%")
         self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · xhigh · think · fast")
         self.assertEqual(rows["Context"]["formattedValue"], "31.35% · 62.7k/200k")
         self.assertAlmostEqual(rows["Context"]["normalizedValue"], 0.3135)
@@ -128,6 +172,8 @@ class StatusLineModeTest(ScriptTestCase):
         row = self.rows(snapshot)["5h"]
         self.assertEqual(row["formattedValue"], "150%")  # 過去のリセット時刻は添えない
         self.assertEqual(row["normalizedValue"], 1.0)  # バーは [0,1] にクランプ
+        # 週間制限が無ければメニューバーの値も出さない (Context では代用しない)
+        self.assertNotIn("metricsBarValue", snapshot)
 
     def test_million_token_context_window(self):
         payload = {"context_window": {
@@ -136,7 +182,6 @@ class StatusLineModeTest(ScriptTestCase):
         }}
         snapshot, _ = self.run_script(json.dumps(payload))
         self.assertEqual(self.rows(snapshot)["Context"]["formattedValue"], "8.4% · 84.5k/1M")
-        self.assertEqual(snapshot["metricsBarValue"], "8%")
 
     def test_project_falls_back_to_directory_name(self):
         payload = {"workspace": {"project_dir": "/Users/so/foo/"}, "worktree": {"name": "my-feature"}}
@@ -151,7 +196,6 @@ class StatusLineModeTest(ScriptTestCase):
         self.assertEqual(rows["Cost"]["formattedValue"], "$0.00")
         self.assertEqual(rows["Edits"]["formattedValue"], "+0 / -0")
         self.assertEqual(rows["Context"]["formattedValue"], "0%")
-        self.assertEqual(snapshot["metricsBarValue"], "0%")
 
     def test_snapshot_is_valid_custom_metrics_schema(self):
         snapshot, _ = self.run_script('{"model": {"display_name": "Opus 4.8"}}')
@@ -185,38 +229,6 @@ class StatusLineModeTest(ScriptTestCase):
 class HookModeTest(ScriptTestCase):
     """hook から呼ばれる経路 (デスクトップアプリではこちらだけが動く)。"""
 
-    def run_hook(self, entries, event="Stop"):
-        """transcript JSONL を作り、hook 入力を流してスナップショットを返す。"""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            transcript = Path(tmpdir) / "transcript.jsonl"
-            transcript.write_text(
-                "".join(json.dumps(e, ensure_ascii=False) + "\n" for e in entries), encoding="utf-8"
-            )
-            snapshot, stdout = self.run_script(json.dumps({
-                "hook_event_name": event,
-                "session_id": "abc123",
-                "transcript_path": str(transcript),
-                "cwd": "/Users/so/.setup",
-            }))
-            # hook の stdout は会話へ混ざり得るので何も出さない
-            self.assertEqual(stdout, "")
-            return snapshot
-
-    def assistant_entry(self, **overrides):
-        entry = {
-            "type": "assistant",
-            "timestamp": "2026-07-23T09:19:24.246Z",
-            "cwd": "/Users/so/.setup",
-            "gitBranch": "feat/runcat-metrics-hook",
-            "effort": "high",
-            "message": {"model": "claude-opus-4-8", "usage": {
-                "input_tokens": 2, "cache_creation_input_tokens": 1970,
-                "cache_read_input_tokens": 138413, "output_tokens": 2163,
-            }},
-        }
-        entry.update(overrides)
-        return entry
-
     def test_transcript_renders_available_rows(self):
         snapshot = self.run_hook([
             {"type": "user", "timestamp": "2026-07-23T08:48:54.157Z", "cwd": "/Users/so/.setup"},
@@ -228,14 +240,14 @@ class HookModeTest(ScriptTestCase):
         self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
         # 142,548 / 200,000 = 71.274% → 小数第 1 位へ丸める
         self.assertEqual(rows["Context"]["formattedValue"], "71.3% · 142.5k/200k")
-        self.assertEqual(snapshot["metricsBarValue"], "71%")
         self.assertEqual(rows["Elapsed"]["formattedValue"], "30m")
         self.assertEqual(rows["Project"]["formattedValue"], "setup · feat/runcat-metrics-hook")
         self.assertEqual(rows["Session"]["formattedValue"], "RunCat 連携")
         self.assertEqual(rows["PR"]["formattedValue"], "#23")
-        # hook 入力からは取れない行は出さない
+        # hook 入力からは取れない行は出さない (5h / 7d は控えが無ければ同様)
         for absent in ("5h", "7d", "Cost", "Edits", "Agent"):
             self.assertNotIn(absent, rows)
+        self.assertNotIn("metricsBarValue", snapshot)
 
     def test_model_id_is_prettified(self):
         for model_id, expected in [
@@ -298,6 +310,79 @@ class HookModeTest(ScriptTestCase):
             self.assertEqual(proc.returncode, 0)
             self.assertEqual(proc.stdout, "")
             self.assertFalse(out.exists())  # 既存のカードを壊さない
+
+
+class RateLimitCacheTest(ScriptTestCase):
+    """レート制限は hook 入力に無いため、statusLine で取れた値を控えて使い回す。"""
+
+    CACHE_NAME = "runcat-rate-limits.json"
+
+    def statusline_payload(self, five_hour=None, seven_day=None):
+        limits = {}
+        if five_hour is not None:
+            limits["five_hour"] = five_hour
+        if seven_day is not None:
+            limits["seven_day"] = seven_day
+        return json.dumps({"model": {"display_name": "Opus 4.8"}, "rate_limits": limits})
+
+    def cache(self, workdir):
+        return json.loads((Path(workdir) / self.CACHE_NAME).read_text(encoding="utf-8"))
+
+    def test_statusline_caches_rate_limits_for_the_hook(self):
+        now = int(time.time())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload(
+                five_hour={"used_percentage": 23.5, "resets_at": now + 9_660 + 30},
+                seven_day={"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
+            ), workdir=tmpdir)
+            self.assertEqual(self.cache(tmpdir)["five_hour"]["used_percentage"], 23.5)
+
+            snapshot = self.run_hook([self.assistant_entry()], workdir=tmpdir)
+            rows = self.rows(snapshot)
+            # 控えは最後に取れた時点の値で実際はそれ以上なので、下限として ≥ を付ける
+            self.assertEqual(rows["5h"]["formattedValue"], "≥23.5% · 2h41m left")
+            self.assertEqual(rows["7d"]["formattedValue"], "≥41.2% · 3d4h left")
+            self.assertEqual(snapshot["metricsBarValue"], "≥41%")
+            # 控えを使っても他の行は transcript 由来のまま
+            self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
+
+    def test_reset_windows_are_not_reused(self):
+        """リセット済みのウィンドウの使用率はもう当てにならないので出さない。"""
+        now = int(time.time())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload(
+                five_hour={"used_percentage": 23.5, "resets_at": now - 60},
+                seven_day={"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
+            ), workdir=tmpdir)
+            rows = self.rows(self.run_hook([self.assistant_entry()], workdir=tmpdir))
+            self.assertNotIn("5h", rows)
+            self.assertEqual(rows["7d"]["formattedValue"], "≥41.2% · 3d4h left")
+
+    def test_windows_without_reset_time_are_not_cached(self):
+        """リセット時刻が無いと古さを判定できないため控えない。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload(
+                five_hour={"used_percentage": 23.5}), workdir=tmpdir)
+            self.assertFalse((Path(tmpdir) / self.CACHE_NAME).exists())
+            self.assertNotIn("5h", self.rows(self.run_hook([self.assistant_entry()], workdir=tmpdir)))
+
+    def test_statusline_without_rate_limits_keeps_the_cache(self):
+        """API キー利用などで制限が来ないターンがあっても、控えを消さない。"""
+        now = int(time.time())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload(
+                seven_day={"used_percentage": 41.2, "resets_at": now + 273_600 + 30}), workdir=tmpdir)
+            self.run_script('{"model": {"display_name": "Opus 4.8"}}', workdir=tmpdir)
+            self.assertEqual(self.cache(tmpdir)["seven_day"]["used_percentage"], 41.2)
+            self.assertIn("7d", self.rows(self.run_hook([self.assistant_entry()], workdir=tmpdir)))
+
+    def test_broken_cache_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / self.CACHE_NAME).write_text("{ truncated", encoding="utf-8")
+            snapshot = self.run_hook([self.assistant_entry()], workdir=tmpdir)
+            rows = self.rows(snapshot)
+            self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
+            self.assertNotIn("5h", rows)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 目的

RunCat Neo のカードに 5 時間制限・週間制限を常に出したい。Claude デスクトップアプリでは statusLine が呼ばれず hook モードだけが動くため、これらの行が消えていた (Context 行だけが残り、しかも hook モードは上限 200k 固定なので 141% のような値になっていた)。

## 変更点

- レート制限の控えを追加。statusLine モードで取れた `five_hour` / `seven_day` を `~/.claude/runcat-rate-limits.json` (出力先と同じディレクトリ) へ原子的に書き、hook モードではリセット時刻を過ぎるまでそれを使う
  - 控えは最後に取れた時点の値で、以後も使用率は上がる一方。下限であることが分かるよう `≥23.5% · 2h41m left` のように `≥` を頭に付ける
  - リセット時刻を持たないウィンドウは古さを判定できないので控えない。制限が来ないターンがあっても既存の控えは消さない
- メニューバーへ出す値 (`metricsBarValue`) を Context の使用率から週間制限の使用率へ変更。Context は行としてはそのまま残す
- `write_snapshot` を `write_json(path, data)` へ一般化 (カードと控えで共用)

## 出せなかったもの

モデル別の週間制限 (Fable) は出せない。Claude Code 2.1.205 のバイナリを確認したところ、内部的には `seven_day_overage_included` (表示名 "Fable 5 limit"、ほかに `seven_day_opus` / `seven_day_sonnet`) という別ウィンドウが存在するが、statusLine へ渡される `rate_limits` の構築は `five_hour` と `seven_day` のみで、hook 入力・transcript にもレート制限は含まれない。取得するには OAuth トークンで `/api/oauth/usage` を直接叩く非公式ルートしかないため見送った。

## 確認方法

- `python3 claude/tests/runcat_metrics_test.py` → 21 tests OK
  - 新規テストは実装側を 6 通り (控えを書かない / 読まない / `≥` を付けない / リセット済みも使う / リセット時刻なしも控える / バー値を Context に戻す) 壊して、いずれも赤くなることを確認済み
- 実データでの手動確認: statusLine 相当の JSON を流してカードと控えが書かれること、続けて実際の transcript で hook モードを走らせ `≥23.5% · 2h40m left` / `metricsBarValue: "≥41%"` が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)