### PR TITLE
fix(claude): op-ssh-sign の署名失敗を環境変数で防ぐ

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "TMPDIR": "/private/tmp"
+  },
   "permissions": {
     "allow": [],
     "additionalDirectories": []
@@ -33,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // \"\"' | grep -qiE -- '--no-gpg-sign|gpgsign[[:space:]=]+(false|0)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"署名なしコミットは禁止(全コミット Verified 運用)。--no-gpg-sign / commit.gpgsign=false を使わず、既定のまま署名付きでコミットする(1Password の op-ssh-sign は非対話でも動作する)。\"}}' || true",
+            "command": "jq -r '.tool_input.command // \"\"' | grep -qiE -- '--no-gpg-sign|gpgsign[[:space:]=]+(false|0)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"署名なしコミットは禁止(全コミット Verified 運用)。--no-gpg-sign / commit.gpgsign=false は使わない。署名が失敗するときは順に対処する: (1) 1Password アプリを起動しロックを解除する (2) TMPDIR=/private/tmp git commit ... で再実行する。サンドボックス既定の TMPDIR からは op-ssh-sign が 1Password に到達できず Could not connect to socket / failed to fill whole buffer になる (3) それでも失敗するならユーザーに報告して指示を仰ぐ。署名のバイパスは最後まで選択肢にしない。\"}}' || true",
             "timeout": 10,
             "statusMessage": "コミット署名ポリシーを確認中"
           }


### PR DESCRIPTION
## 目的

Claude Code のセッションから `git commit` すると、1Password の `op-ssh-sign` による署名が
次のエラーで失敗することが頻発する。

```
error: 1Password: Could not connect to socket. Is the agent running?
error: 1Password: failed to fill whole buffer
fatal: failed to write commit object
```

実際に calverge の作業で **3 つのエージェントが同時に足止め**され、いずれも
「1Password をアンロックしてほしい」と報告して停止した。アンロック済みでも再発する。

## 分かったこと

`TMPDIR=/private/tmp` を前置すると**確実に通る**(同一セッション内で A/B を確認)。

| TMPDIR | 結果 |
| --- | --- |
| サンドボックス既定 (`/var/folders/.../T/`) | `Could not connect to socket` で失敗 |
| `/private/tmp` | 署名成功(`git log --show-signature` で Good signature) |

1Password アプリの起動・アンロック、SSH agent への鍵のロードはいずれも済んだ状態で
この差が出るため、`op-ssh-sign` が一時ディレクトリ経由で 1Password と通信する経路が
サンドボックス既定の TMPDIR では通らないものと考えられる。

> 補足: 既定の TMPDIR でもまれに成功することがあり、根本原因の断定はできていない。
> ここで入れるのは**実機で再現性を確認した回避策**であり、原因究明ではない。

## 変更点

1. **`env.TMPDIR = /private/tmp` を追加** — 以後すべてのセッションで署名が通る。
   Claude Code から走る全コマンドの一時ディレクトリが `/private/tmp` になるが、
   単一ユーザーの Mac では実害がないと判断した
2. **署名バイパスを拒否する PreToolUse フックの文面を改訂** — 従来は
   「op-ssh-sign は非対話でも動作する」とだけ書いており、実際に署名が失敗したときの
   出口が無かった。ロック解除 → TMPDIR の前置 → ユーザーへ報告、の順に案内する

## 確認方法

- `python3 -m json.tool claude/settings.json` が通る(JSON 妥当)
- `jq -e '.hooks.PreToolUse[] | select(.matcher=="Bash") | .hooks[]'` でフック定義を確認
- フックに実際の入力を流し、新しい文面が返ることを確認:

  ```sh
  echo '{"tool_input":{"command":"git commit --no-gpg-sign -m x"}}' \
    | bash -c "$(jq -r '.hooks.PreToolUse[0].hooks[0].command' claude/settings.json)"
  ```

- **このコミット自体が `TMPDIR=/private/tmp` で署名付きに成功している**(`%G?` が `G`)

## 既知の副作用

フックはコマンド文字列全体を grep するため、**コミットメッセージ本文に該当フラグ名を
書くと誤検知で拒否される**(この PR の作成中に踏んだ)。`git commit -F <file>` で回避できる。
安全側の誤検知なので今回は直していない。

## 反映

`env` の変更が効くのは**次のセッションから**。現行セッションでは従来どおり
`TMPDIR=/private/tmp` の前置が要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
