### PR TITLE
feat(claude): RunCat のカードを同時実行セッションに対応させる

### DIFF
--- a/claude/runcat-metrics.py
+++ b/claude/runcat-metrics.py
@@ -20,11 +20,22 @@ RunCat Neo の Custom Metrics 形式
    (https://code.claude.com/docs/en/hooks) ので、渡される transcript_path の
    JSONL 末尾を読んで組み立てる。stdout には何も出さない。
 
-出力される行 (値が取れない行は出さない。◯=そのモードで取れる):
+カードは 1 枚しか無いのに Claude Code は同時に何セッションも動く。そこで各実行は
+まず自分の状態を SESSIONS_DIR/<session_id>.json へ書き、次に生きている全セッション
+(最終更新が SESSION_TTL_SECONDS 以内) を読み直してカードを組む。これで最後に走った
+セッションが他を上書きしてしまうことがなくなる。
+
+カードの形は生きているセッション数で変わる:
+
+  1 つ  → そのセッションの詳細を 1 行 1 項目で出す (下表)
+  2 つ+ → レート制限を頭に置き、以降はセッションごとに 1 行へ畳む
+          (例: `setup   21% · Opus 5 · 12m`)。行数とカード幅を抑えるため。
+
+詳細レイアウトで出る行 (値が取れない行は出さない。◯=そのモードで取れる):
 
     行       例                                 statusLine  hook
-    Model    Opus 4.8 · xhigh · think · fast        ◯    ◯ (think/fast は無し)
-    Context  31% · 62.5k/200k                       ◯    ◯ (上限は 200k 固定)
+    Model    Opus 5 · xhigh · think · fast          ◯    ◯ (think/fast は無し)
+    Context  31% · 62.5k/200k                       ◯    ◯ (上限は推定値)
     5h / 7d  23.5% · 2h41m left                     ◯    △ (statusLine の控えを使う)
     Cost     $0.42                                  ◯    ✗ (hook 入力に無い。トークン単価も持たない)
     Elapsed  45m · API 2m18s                        ◯    ◯ (API 時間は無し)
@@ -38,22 +49,30 @@ RunCat Neo の Custom Metrics 形式
 
 レート制限は hook 入力にも transcript にも無いため、statusLine モードで取れた値を
 控え (RATE_LIMITS_CACHE)、hook モードではリセット時刻を過ぎるまでそれを使う。
-控えは最後に取れた時点の値で実際はそれ以上なので、下限として ≥ を頭に付けて出す。
+控えは最後に取れた時点の値で実際はそれ以上なので、下限として ≥ を付けて出す。
 モデル別の週間制限 (Opus / Sonnet / Fable) は Claude Code が statusLine へ渡すのが
-five_hour と seven_day だけのため出せない (2.1.205 時点)。
+five_hour と seven_day だけのため出せない (2.1.212 時点)。
+
+文脈の上限は statusLine 入力にしか無い。hook モードではモデル名から引く
+(200k なのは Haiku 4.5 だけで、Claude 5 系はいずれも 1M が既定)。
+
+カードの幅は一番長い行に引きずられるので、可変長の値 (プロジェクト名・ブランチ名・
+セッション名) は MAX_VALUE_WIDTH 幅で切り詰める。
 
 意図的に出していないもの: session_id・prompt_id・transcript_path・cwd (カード向きでない
 ID / パス)、version・output_style.name・vim.mode (常時見る価値が薄い)、
 exceeds_200k_tokens (Context 行と重複。1M コンテキストのモデルでのみ差が出る)。
 
 環境変数 RUNCAT_OUT_FILE で出力先を上書きできる (既定: ~/.claude/runcat-usage.json)。
-レート制限の控えは同じディレクトリの runcat-rate-limits.json に置く。
+レート制限の控えとセッションごとの状態は同じディレクトリに置く。
 """
 
 import json
 import os
+import re
 import sys
 import tempfile
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -62,11 +81,27 @@ OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runc
 # statusLine で取れたレート制限の控え (hook モードから読む)
 RATE_LIMITS_CACHE = OUT.parent / "runcat-rate-limits.json"
 
-# hook モードでは文脈上限が入力に無いため既定値を使う (1M コンテキストのモデルでは過大に出る)
-DEFAULT_CONTEXT_WINDOW = 200_000
+# セッションごとの状態 (<session_id>.json)。カードはここを集約して組む
+SESSIONS_DIR = OUT.parent / "runcat-sessions"
+
+# これを過ぎて更新の無いセッションは終了したとみなす。ターン間の間隔より十分長く取る
+SESSION_TTL_SECONDS = 30 * 60
+
+# 掃除の閾値。TTL を過ぎても暫くは残し、古すぎるものだけ消す
+SESSION_PURGE_SECONDS = 24 * 60 * 60
+
+# hook モードでは文脈上限が入力に無いためモデル名から引く。現行モデルで 200k なのは
+# Haiku 4.5 だけで、Claude 5 系 (Opus / Sonnet / Fable) はいずれも 1M が既定
+# (ベータヘッダも長文脈の追加料金も無い)
+SMALL_CONTEXT_MODELS = ("haiku",)
+SMALL_CONTEXT_WINDOW = 200_000
+DEFAULT_CONTEXT_WINDOW = 1_000_000
 
 # transcript は伸び続けるので末尾のこのサイズだけ読む (毎ツール呼び出しで走るため)
 TRANSCRIPT_TAIL_BYTES = 256 * 1024
+
+# 可変長の値をこの表示幅で切る (全角は 2 幅)。カードが横に伸びるのを防ぐ
+MAX_VALUE_WIDTH = 28
 
 
 # --- 整形ヘルパー -------------------------------------------------------------
@@ -86,6 +121,28 @@ def obj(payload, *keys):
             return {}
         current = current.get(key)
     return current if isinstance(current, dict) else {}
+
+
+def text_width(text):
+    """全角 (東アジア幅 W/F) を 2 と数えた表示幅。"""
+    return sum(2 if unicodedata.east_asian_width(c) in "WF" else 1 for c in text)
+
+
+def clip(text, limit=MAX_VALUE_WIDTH):
+    """表示幅が limit に収まるよう末尾を … で省略する。"""
+    if text is None:
+        return None
+    text = str(text)
+    if text_width(text) <= limit:
+        return text
+    kept, width = [], 0
+    for char in text:
+        char_width = 2 if unicodedata.east_asian_width(char) in "WF" else 1
+        if width + char_width > limit - 1:  # … の 1 幅を残す
+            break
+        kept.append(char)
+        width += char_width
+    return "".join(kept).rstrip() + "…"
 
 
 def row(title, formatted, normalized=None):
@@ -125,7 +182,7 @@ def fmt_duration(seconds):
 
 
 def fmt_model_id(model_id):
-    """モデル ID を表示名へ (claude-opus-4-8 → Opus 4.8, claude-haiku-4-5-20251001 → Haiku 4.5)。"""
+    """モデル ID を表示名へ (claude-opus-5 → Opus 5, claude-haiku-4-5-20251001 → Haiku 4.5)。"""
     if not isinstance(model_id, str) or not model_id:
         return None
     parts = [p for p in model_id.split("-") if p and p != "claude"]
@@ -135,6 +192,20 @@ def fmt_model_id(model_id):
         return None
     version = ".".join(parts[1:])
     return f"{parts[0].capitalize()} {version}".strip()
+
+
+def guess_context_window(model_name, used_tokens):
+    """hook モード用の文脈上限をモデル名から引く。
+
+    statusLine 入力と違い hook 入力には上限が無い。現行モデルで 200k なのは
+    Haiku 4.5 だけなので二択に落とし、既定は 1M とする。表に無い上限のモデルでも
+    使用率が 100% を超えないよう、使用量が上限を上回ったら使用量を上限とみなす。
+    """
+    name = str(model_name or "").lower()
+    size = SMALL_CONTEXT_WINDOW if any(m in name for m in SMALL_CONTEXT_MODELS) else DEFAULT_CONTEXT_WINDOW
+    if used_tokens and used_tokens > size:
+        return used_tokens
+    return size
 
 
 def context_row(used_tokens, size_tokens, used_pct=None):
@@ -222,12 +293,129 @@ def load_rate_limits(now_epoch):
     }
 
 
+# --- セッションごとの状態 --------------------------------------------------------
+
+def session_filename(session_id):
+    """session_id をファイル名へ。パス区切りなどが混ざっても安全な形に落とす。"""
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", str(session_id or "unknown"))
+    return f"{safe[:96] or 'unknown'}.json"
+
+
+def save_session(state):
+    """このセッションの状態を書き出す。カードは全セッション分から組む。"""
+    write_json(SESSIONS_DIR / session_filename(state.get("session_id")), state)
+
+
+def load_sessions(now_epoch, current_id=None):
+    """生きているセッションの状態を、更新の新しい順に返す。
+
+    TTL を過ぎたものは畳み、さらに古いファイルは掃除する。current_id は
+    自分の状態 (今書いたばかり) で、TTL 判定に関わらず必ず含める。
+    """
+    states = []
+    try:
+        paths = sorted(SESSIONS_DIR.iterdir())
+    except Exception:
+        return states
+    current_name = session_filename(current_id) if current_id is not None else None
+    for path in paths:
+        if path.suffix != ".json":
+            continue
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(state, dict):
+            continue
+        age = now_epoch - (num(state.get("updated_at")) or 0)
+        if path.name == current_name or age <= SESSION_TTL_SECONDS:
+            states.append(state)
+        elif age > SESSION_PURGE_SECONDS:
+            try:
+                path.unlink()
+            except Exception:
+                pass
+    states.sort(key=lambda s: num(s.get("updated_at")) or 0, reverse=True)
+    return states
+
+
+def session_label(state, states):
+    """セッション行のラベル。同じプロジェクトが複数あるときだけブランチを添える。"""
+    project = state.get("project") or state.get("title") or "session"
+    same = [s for s in states if (s.get("project") or s.get("title")) == project]
+    if len(same) > 1 and state.get("branch"):
+        project = f"{project} · {state['branch']}"
+    return clip(project, 20)
+
+
+def session_summary(state):
+    """セッション行の値。使用率・モデル・経過を 1 行へ畳む。"""
+    parts = []
+    ctx_pct = num(state.get("ctx_pct"))
+    if ctx_pct is not None:
+        parts.append(f"{ctx_pct:g}%")
+    if state.get("model"):
+        parts.append(str(state["model"]))
+    if state.get("elapsed"):
+        parts.append(str(state["elapsed"]))
+    return " · ".join(parts) or None
+
+
+# --- カードの組み立て -----------------------------------------------------------
+
+def detail_metrics(state, limits, now_epoch, stale):
+    """セッションが 1 つのときのレイアウト (1 行 1 項目)。"""
+    ctx_pct = num(state.get("ctx_pct"))
+    ctx_row = None
+    if ctx_pct is not None:
+        ctx_row = context_row(state.get("ctx_used"), state.get("ctx_size"), ctx_pct)
+    project = state.get("project")
+    branch = state.get("branch")
+    return [
+        row("Model", state.get("model")),
+        ctx_row,
+        rate_limit_row("5h", limits.get("five_hour", {}), now_epoch, stale=stale),
+        rate_limit_row("7d", limits.get("seven_day", {}), now_epoch, stale=stale),
+        row("Cost", state.get("cost")),
+        row("Elapsed", state.get("elapsed")),
+        row("Edits", state.get("edits")),
+        row("Project", clip(f"{project} · {branch}" if project and branch else (project or branch))),
+        row("Session", clip(state.get("title"))),
+        row("Agent", clip(state.get("agent"))),
+        row("PR", state.get("pr")),
+    ]
+
+
+def summary_metrics(states, limits, now_epoch, stale):
+    """セッションが複数のときのレイアウト (レート制限 + 1 セッション 1 行)。"""
+    metrics = [
+        rate_limit_row("5h", limits.get("five_hour", {}), now_epoch, stale=stale),
+        rate_limit_row("7d", limits.get("seven_day", {}), now_epoch, stale=stale),
+    ]
+    for state in states:
+        ctx_pct = num(state.get("ctx_pct"))
+        metrics.append(row(
+            session_label(state, states),
+            session_summary(state),
+            ctx_pct / 100 if ctx_pct is not None else None,
+        ))
+    return metrics
+
+
+def build_card(states, limits, now_epoch, stale):
+    """生きているセッションからカードを組む。"""
+    if len(states) <= 1:
+        state = states[0] if states else {}
+        metrics = detail_metrics(state, limits, now_epoch, stale)
+    else:
+        metrics = summary_metrics(states, limits, now_epoch, stale)
+    return snapshot(metrics, fmt_bar_value(limits.get("seven_day", {}), stale=stale))
+
+
 # --- statusLine モード ---------------------------------------------------------
 
-
 def from_statusline(payload):
-    now_epoch = datetime.now(timezone.utc).timestamp()
-
+    """statusLine 入力からこのセッションの状態を組む。"""
     # Model: モデル名に effort / extended thinking / fast mode のマーカーを添える
     model_name = obj(payload, "model").get("display_name") or "Claude Code"
     parts = [str(model_name)]
@@ -244,15 +432,6 @@ def from_statusline(payload):
     in_tokens = num(context.get("total_input_tokens"))
     out_tokens = num(context.get("total_output_tokens"))
     used_tokens = (in_tokens or 0) + (out_tokens or 0) if (in_tokens is not None or out_tokens is not None) else None
-    ctx_row = None
-    if ctx_pct is not None:
-        ctx_row = context_row(used_tokens, num(context.get("context_window_size")), ctx_pct)
-
-    # レート制限: hook モード (デスクトップアプリ) では取れないのでここで控えておく
-    five_hour = obj(payload, "rate_limits", "five_hour")
-    seven_day = obj(payload, "rate_limits", "seven_day")
-    if five_hour or seven_day:
-        save_rate_limits({"five_hour": five_hour, "seven_day": seven_day})
 
     # Cost / Elapsed / Edits
     cost = obj(payload, "cost")
@@ -266,8 +445,7 @@ def from_statusline(payload):
     added = num(cost.get("total_lines_added"))
     removed = num(cost.get("total_lines_removed"))
 
-    # Project: リポジトリ名 (なければ起動ディレクトリ名) に worktree 名を添える。
-    # 複数セッションが同じ JSON を上書きするため、どのセッションの値かを見分ける手掛かりになる
+    # Project: リポジトリ名 (なければ起動ディレクトリ名) に worktree 名を添える
     workspace = obj(payload, "workspace")
     project = obj(workspace, "repo").get("name")
     if not project and workspace.get("project_dir"):
@@ -280,20 +458,23 @@ def from_statusline(payload):
     if pr_text and pr.get("review_state"):
         pr_text += f" · {pr['review_state']}"
 
-    metrics = [
-        row("Model", " · ".join(parts)),
-        ctx_row,
-        rate_limit_row("5h", five_hour, now_epoch),
-        rate_limit_row("7d", seven_day, now_epoch),
-        row("Cost", f"${cost_usd:,.2f}" if cost_usd is not None else None),
-        row("Elapsed", elapsed),
-        row("Edits", f"+{added:.0f} / -{removed:.0f}" if added is not None and removed is not None else None),
-        row("Project", f"{project} · {worktree}" if project and worktree else (project or worktree)),
-        row("Session", payload.get("session_name")),
-        row("Agent", obj(payload, "agent").get("name")),
-        row("PR", pr_text),
-    ]
-    return snapshot(metrics, fmt_bar_value(seven_day)), str(model_name)
+    state = {
+        "session_id": payload.get("session_id"),
+        "updated_at": datetime.now(timezone.utc).timestamp(),
+        "model": " · ".join(parts),
+        "ctx_pct": ctx_pct,
+        "ctx_used": used_tokens,
+        "ctx_size": num(context.get("context_window_size")),
+        "cost": f"${cost_usd:,.2f}" if cost_usd is not None else None,
+        "elapsed": elapsed,
+        "edits": f"+{added:.0f} / -{removed:.0f}" if added is not None and removed is not None else None,
+        "project": project,
+        "branch": worktree,
+        "title": payload.get("session_name"),
+        "agent": obj(payload, "agent").get("name"),
+        "pr": pr_text,
+    }
+    return state, str(model_name)
 
 
 # --- hook モード ---------------------------------------------------------------
@@ -328,6 +509,18 @@ def last_with(entries, key):
     return None
 
 
+def project_from_cwd(cwd):
+    """起動ディレクトリからプロジェクト名を取る。
+
+    worktree の中では末尾が worktree 名になり、どのリポジトリか分からなくなる。
+    ブランチ名は別に出しているので、ここは元のリポジトリ名の方が役に立つ。
+    """
+    marker = "/.claude/worktrees/"
+    if marker in cwd:
+        cwd = cwd.split(marker)[0]
+    return os.path.basename(cwd.rstrip("/")) or None
+
+
 def parse_ts(value):
     if not isinstance(value, str):
         return None
@@ -337,8 +530,8 @@ def parse_ts(value):
         return None
 
 
-def from_transcript(path):
-    now_epoch = datetime.now(timezone.utc).timestamp()
+def from_transcript(path, session_id=None):
+    """transcript からこのセッションの状態を組む (hook 入力に無い項目は落とす)。"""
     entries = read_transcript(path)
     assistants = [e for e in entries if e.get("type") == "assistant" and not e.get("isSidechain")]
     last = assistants[-1] if assistants else {}
@@ -355,11 +548,8 @@ def from_transcript(path):
         num(usage.get(k)) or 0
         for k in ("input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens", "output_tokens")
     ) or None
-    ctx_row = context_row(used_tokens, DEFAULT_CONTEXT_WINDOW)
-
-    # レート制限: hook 入力には無いので statusLine モードの控えを使う
-    cached_limits = load_rate_limits(now_epoch)
-    seven_day = cached_limits.get("seven_day", {})
+    ctx_size = guess_context_window(message.get("model"), used_tokens)
+    ctx_pct = round(used_tokens / ctx_size * 100, 1) if used_tokens else None
 
     # Elapsed: transcript の最初と最後のエントリの時刻差
     start = parse_ts(entries[0].get("timestamp")) if entries else None
@@ -371,26 +561,38 @@ def from_transcript(path):
     cwd = last_with(entries, "cwd")
     project = repository.split("/")[-1] if isinstance(repository, str) and repository else None
     if not project and isinstance(cwd, str):
-        project = os.path.basename(cwd.rstrip("/"))
+        project = project_from_cwd(cwd)
     branch = last_with(entries, "gitBranch")
 
     pr_number = last_with(entries, "prNumber")
     title = last_with(entries, "customTitle") or last_with(entries, "aiTitle")
 
-    metrics = [
-        row("Model", " · ".join(parts)),
-        ctx_row,
-        rate_limit_row("5h", cached_limits.get("five_hour", {}), now_epoch, stale=True),
-        rate_limit_row("7d", seven_day, now_epoch, stale=True),
-        row("Elapsed", elapsed),
-        row("Project", f"{project} · {branch}" if project and branch else (project or branch)),
-        row("Session", title),
-        row("PR", f"#{pr_number}" if pr_number is not None else None),
-    ]
-    return snapshot(metrics, fmt_bar_value(seven_day, stale=True))
+    return {
+        "session_id": session_id or last_with(entries, "sessionId"),
+        "updated_at": datetime.now(timezone.utc).timestamp(),
+        "model": " · ".join(parts),
+        "ctx_pct": ctx_pct,
+        "ctx_used": used_tokens,
+        "ctx_size": ctx_size if used_tokens else None,
+        "cost": None,
+        "elapsed": elapsed,
+        "edits": None,
+        "project": project,
+        "branch": branch,
+        "title": title,
+        "agent": None,
+        "pr": f"#{pr_number}" if pr_number is not None else None,
+    }
 
 
 # --- エントリポイント -----------------------------------------------------------
+
+def render(state, limits, now_epoch, stale):
+    """自分の状態を保存し、生きている全セッションからカードを組んで書き出す。"""
+    save_session(state)
+    states = load_sessions(now_epoch, current_id=state.get("session_id"))
+    write_json(OUT, build_card(states, limits, now_epoch, stale))
+
 
 def main():
     try:
@@ -400,16 +602,27 @@ def main():
     except Exception:
         payload = {}
 
+    now_epoch = datetime.now(timezone.utc).timestamp()
+
     if payload.get("hook_event_name"):
         # hook を止めないよう、失敗しても黙って終了する
         try:
-            write_json(OUT, from_transcript(payload["transcript_path"]))
+            state = from_transcript(payload["transcript_path"], payload.get("session_id"))
+            # レート制限は hook 入力に無いので statusLine モードの控えを使う
+            render(state, load_rate_limits(now_epoch), now_epoch, stale=True)
         except Exception:
             pass
         return
 
-    data, model_name = from_statusline(payload)
-    write_json(OUT, data)
+    state, model_name = from_statusline(payload)
+
+    # レート制限: hook モード (デスクトップアプリ) では取れないのでここで控えておく
+    five_hour = obj(payload, "rate_limits", "five_hour")
+    seven_day = obj(payload, "rate_limits", "seven_day")
+    if five_hour or seven_day:
+        save_rate_limits({"five_hour": five_hour, "seven_day": seven_day})
+
+    render(state, {"five_hour": five_hour, "seven_day": seven_day}, now_epoch, stale=False)
     print(model_name)
 
 

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import unicodedata
 import unittest
 from pathlib import Path
 
@@ -223,7 +224,10 @@ class StatusLineModeTest(ScriptTestCase):
                 env={"RUNCAT_OUT_FILE": str(out), "PATH": "/usr/bin:/bin", "HOME": tmpdir},
             )
             self.assertEqual(json.loads(out.read_text(encoding="utf-8"))["title"], "Claude Code")
-            self.assertEqual([p.name for p in Path(tmpdir).iterdir()], ["usage.json"])
+            # 出力とセッション状態だけが残る (書きかけの一時ファイルを残さない)
+            self.assertEqual(
+                sorted(p.name for p in Path(tmpdir).iterdir()), ["runcat-sessions", "usage.json"])
+            self.assertEqual([p.suffix for p in (Path(tmpdir) / "runcat-sessions").iterdir()], [".json"])
 
 
 class HookModeTest(ScriptTestCase):
@@ -238,10 +242,11 @@ class HookModeTest(ScriptTestCase):
         ])
         rows = self.rows(snapshot)
         self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
-        # 142,548 / 200,000 = 71.274% → 小数第 1 位へ丸める
-        self.assertEqual(rows["Context"]["formattedValue"], "71.3% · 142.5k/200k")
+        # Opus は 1M 文脈。142,548 / 1M = 14.2548% → 小数第 1 位へ丸める
+        self.assertEqual(rows["Context"]["formattedValue"], "14.3% · 142.5k/1M")
         self.assertEqual(rows["Elapsed"]["formattedValue"], "30m")
-        self.assertEqual(rows["Project"]["formattedValue"], "setup · feat/runcat-metrics-hook")
+        # 28 幅を超える値は切り詰める (カードが横に伸びるのを防ぐ)
+        self.assertEqual(rows["Project"]["formattedValue"], "setup · feat/runcat-metrics…")
         self.assertEqual(rows["Session"]["formattedValue"], "RunCat 連携")
         self.assertEqual(rows["PR"]["formattedValue"], "#23")
         # hook 入力からは取れない行は出さない (5h / 7d は控えが無ければ同様)
@@ -261,6 +266,14 @@ class HookModeTest(ScriptTestCase):
                     message={"model": model_id, "usage": {}}, effort=None)])
                 self.assertEqual(self.rows(snapshot)["Model"]["formattedValue"], expected)
 
+    def test_worktree_cwd_falls_back_to_the_repository_name(self):
+        """worktree の中では末尾が worktree 名になるので、元のリポジトリ名を出す。"""
+        snapshot = self.run_hook([self.assistant_entry(
+            cwd="/Users/so/Repos/myapp/.claude/worktrees/feat-something-250692",
+            gitBranch="feat/something")])
+        self.assertEqual(
+            self.rows(snapshot)["Project"]["formattedValue"], "myapp · feat/something")
+
     def test_sidechain_entries_are_ignored(self):
         """サブエージェント (isSidechain) の usage は本セッションの文脈量ではない。"""
         snapshot = self.run_hook([
@@ -270,7 +283,7 @@ class HookModeTest(ScriptTestCase):
         ])
         rows = self.rows(snapshot)
         self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
-        self.assertEqual(rows["Context"]["formattedValue"], "71.3% · 142.5k/200k")
+        self.assertEqual(rows["Context"]["formattedValue"], "14.3% · 142.5k/1M")
 
     def test_broken_transcript_lines_are_skipped(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -323,7 +336,13 @@ class RateLimitCacheTest(ScriptTestCase):
             limits["five_hour"] = five_hour
         if seven_day is not None:
             limits["seven_day"] = seven_day
-        return json.dumps({"model": {"display_name": "Opus 4.8"}, "rate_limits": limits})
+        # run_hook と同じセッションとして扱わせる (statusLine と hook は同一セッションの
+        # 別入口なので、session_id が揃っていないと 2 セッション分のカードになる)
+        return json.dumps({
+            "session_id": "abc123",
+            "model": {"display_name": "Opus 4.8"},
+            "rate_limits": limits,
+        })
 
     def cache(self, workdir):
         return json.loads((Path(workdir) / self.CACHE_NAME).read_text(encoding="utf-8"))
@@ -383,6 +402,173 @@ class RateLimitCacheTest(ScriptTestCase):
             rows = self.rows(snapshot)
             self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
             self.assertNotIn("5h", rows)
+
+
+class MultiSessionTest(ScriptTestCase):
+    """カードは 1 枚しか無いので、同時に動くセッションを畳んで並べる。"""
+
+    SESSIONS_DIR = "runcat-sessions"
+
+    def statusline_payload(self, session_id, project, used_percentage, duration_ms, branch=None,
+                           model="Opus 5"):
+        payload = {
+            "session_id": session_id,
+            "model": {"display_name": model},
+            "workspace": {"repo": {"name": project}},
+            "context_window": {"used_percentage": used_percentage},
+            "cost": {"total_duration_ms": duration_ms},
+        }
+        if branch is not None:
+            payload["workspace"]["git_worktree"] = branch
+        return json.dumps(payload)
+
+    def state_files(self, workdir):
+        return sorted((Path(workdir) / self.SESSIONS_DIR).iterdir())
+
+    def age_session(self, workdir, seconds):
+        """状態ファイルの更新時刻を過去へずらす (TTL 判定は状態の中身で行う)。"""
+        for path in self.state_files(workdir):
+            state = json.loads(path.read_text(encoding="utf-8"))
+            state["updated_at"] = state["updated_at"] - seconds
+            path.write_text(json.dumps(state), encoding="utf-8")
+
+    def test_every_live_session_gets_a_row(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload("s1", "setup", 21, 4_500_000), workdir=tmpdir)
+            snapshot, _ = self.run_script(
+                self.statusline_payload("s2", "divive", 8, 180_000), workdir=tmpdir)
+            rows = self.rows(snapshot)
+
+            # セッションごとに 1 行へ畳む (使用率 · モデル · 経過)
+            self.assertEqual(rows["setup"]["formattedValue"], "21% · Opus 5 · 1h15m")
+            self.assertEqual(rows["divive"]["formattedValue"], "8% · Opus 5 · 3m")
+            self.assertAlmostEqual(rows["setup"]["normalizedValue"], 0.21)
+            # 畳んだので 1 項目 1 行の詳細レイアウトは出さない
+            for absent in ("Model", "Context", "Project", "Elapsed"):
+                self.assertNotIn(absent, rows)
+
+    def test_single_session_keeps_the_detail_layout(self):
+        """1 つだけのときは畳まず詳細を出す (情報量を落とさない)。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            snapshot, _ = self.run_script(
+                self.statusline_payload("s1", "setup", 21, 4_500_000), workdir=tmpdir)
+            rows = self.rows(snapshot)
+            self.assertEqual(rows["Model"]["formattedValue"], "Opus 5")
+            self.assertEqual(rows["Context"]["formattedValue"], "21%")
+            self.assertEqual(rows["Project"]["formattedValue"], "setup")
+            self.assertNotIn("setup", rows)
+
+    def test_stale_sessions_are_dropped(self):
+        """終了したセッションはカードに残さない (更新が途絶えたら畳む)。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload("s1", "setup", 21, 4_500_000), workdir=tmpdir)
+            self.age_session(tmpdir, 31 * 60)  # SESSION_TTL_SECONDS (30 分) 超え
+            snapshot, _ = self.run_script(
+                self.statusline_payload("s2", "divive", 8, 180_000), workdir=tmpdir)
+            rows = self.rows(snapshot)
+            # 生きているのは s2 だけなので詳細レイアウトに戻る
+            self.assertEqual(rows["Project"]["formattedValue"], "divive")
+            self.assertNotIn("setup", rows)
+
+    def test_same_project_rows_are_told_apart_by_branch(self):
+        """同じリポジトリの worktree を 2 つ開くとラベルが衝突するのでブランチを添える。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(
+                self.statusline_payload("s1", "setup", 21, 60_000, branch="feat/a"), workdir=tmpdir)
+            snapshot, _ = self.run_script(
+                self.statusline_payload("s2", "setup", 8, 60_000, branch="feat/b"), workdir=tmpdir)
+            rows = self.rows(snapshot)
+            self.assertIn("setup · feat/a", rows)
+            self.assertIn("setup · feat/b", rows)
+
+    def test_rate_limits_lead_the_folded_card(self):
+        """畳んだ形でもレート制限は主役のまま先頭に置く。"""
+        now = int(time.time())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload("s1", "setup", 21, 60_000), workdir=tmpdir)
+            payload = json.loads(self.statusline_payload("s2", "divive", 8, 60_000))
+            payload["rate_limits"] = {
+                "five_hour": {"used_percentage": 23.5, "resets_at": now + 9_660 + 30},
+                "seven_day": {"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
+            }
+            snapshot, _ = self.run_script(json.dumps(payload), workdir=tmpdir)
+
+            self.assertEqual([m["title"] for m in snapshot["metrics"]][:2], ["5h", "7d"])
+            self.assertEqual(snapshot["metricsBarValue"], "41%")
+
+    def test_statusline_and_hook_share_one_row_per_session(self):
+        """同じセッションの 2 つの入口が別行に割れない。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload("abc123", "setup", 21, 60_000), workdir=tmpdir)
+            self.run_hook([self.assistant_entry()], workdir=tmpdir)  # session_id は abc123
+            self.assertEqual(len(self.state_files(tmpdir)), 1)
+
+    def test_session_id_is_not_used_as_a_path(self):
+        """session_id は外から来る値なので、そのままファイル名にしない。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(self.statusline_payload("../../escape", "setup", 21, 60_000),
+                            workdir=tmpdir)
+            files = self.state_files(tmpdir)
+            self.assertEqual([p.name for p in files], ["______escape.json"])
+
+
+class DisplayWidthTest(ScriptTestCase):
+    """カード幅は一番長い行に引きずられるため、可変長の値は切り詰める。"""
+
+    def width(self, text):
+        return sum(2 if unicodedata.east_asian_width(c) in "WF" else 1 for c in text)
+
+    def test_long_values_are_clipped(self):
+        payload = {
+            "session_name": "アドオンのプロダクション対応レビューと後片付け",
+            "workspace": {
+                "repo": {"name": "setup"},
+                "git_worktree": "global-claude-md-symlinks-250692",
+            },
+        }
+        snapshot, _ = self.run_script(json.dumps(payload))
+        rows = self.rows(snapshot)
+        # 全角は 2 幅として数える (28 幅 = 全角 14 文字 / 半角 28 文字)
+        self.assertEqual(rows["Session"]["formattedValue"], "アドオンのプロダクション対…")
+        self.assertEqual(rows["Project"]["formattedValue"], "setup · global-claude-md-sy…")
+        for title in ("Session", "Project"):
+            self.assertLessEqual(self.width(rows[title]["formattedValue"]), 28)
+
+    def test_short_values_are_left_alone(self):
+        payload = {"session_name": "runcat", "workspace": {"repo": {"name": "setup"}}}
+        rows = self.rows(self.run_script(json.dumps(payload))[0])
+        self.assertEqual(rows["Session"]["formattedValue"], "runcat")
+        self.assertEqual(rows["Project"]["formattedValue"], "setup")
+
+
+class ContextWindowTest(ScriptTestCase):
+    """hook 入力には文脈の上限が無いので、モデル名から引く。"""
+
+    def usage_entry(self, model, cache_read):
+        return self.assistant_entry(message={"model": model, "usage": {
+            "input_tokens": 2, "cache_creation_input_tokens": 1_970,
+            "cache_read_input_tokens": cache_read, "output_tokens": 2_163,
+        }})
+
+    def test_claude_5_models_get_the_1m_window(self):
+        """Opus / Sonnet / Fable 5 はいずれも 1M が既定 (ベータヘッダ不要)。"""
+        for model in ("claude-opus-5", "claude-sonnet-5", "claude-fable-5"):
+            with self.subTest(model=model):
+                rows = self.rows(self.run_hook([self.usage_entry(model, 411_465)]))
+                # 415,600 / 1M = 41.56% → 小数第 1 位へ丸める
+                self.assertEqual(rows["Context"]["formattedValue"], "41.6% · 415.6k/1M")
+                self.assertAlmostEqual(rows["Context"]["normalizedValue"], 0.416)
+
+    def test_haiku_gets_the_200k_window(self):
+        """現行モデルで 200k なのは Haiku 4.5 だけ。"""
+        rows = self.rows(self.run_hook([self.usage_entry("claude-haiku-4-5-20251001", 138_413)]))
+        self.assertEqual(rows["Context"]["formattedValue"], "71.3% · 142.5k/200k")
+
+    def test_usage_above_the_known_window_does_not_exceed_100_percent(self):
+        """表に無い上限のモデルでも 100% 超えの表示にはしない。"""
+        rows = self.rows(self.run_hook([self.usage_entry("claude-haiku-4-5", 411_465)]))
+        self.assertEqual(rows["Context"]["formattedValue"], "100% · 415.6k/415.6k")
+        self.assertEqual(rows["Context"]["normalizedValue"], 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 目的

「RunCat Neo で 3 つのメトリクスが見えない」「コンテキストだけが見えていて古いまま」という報告の調査から。カードは 1 枚しか無いのに Claude Code は同時に何セッションも動くため、最後に hook を走らせたセッションが他を上書きし、今見ているセッションと無関係な値が出ていた。1 分の間にカードの Project が `divive` → `setup · feat/interactive-affordance` と入れ替わることを実測している。

あわせて Context 行が `207.8% · 415.6k/200k` と壊れていた。hook モードの文脈上限が 200k 固定で、Opus 5 の 1M コンテキストに追従していなかったため。

## 変更点

各実行がまず自分の状態を `runcat-sessions/<session_id>.json` へ書き、生きているセッション (最終更新が 30 分以内) を読み直してカードを組むようにした。

- **同時実行セッションを全部出す** — 2 つ以上ならレート制限を頭に置き、以降は 1 セッション 1 行へ畳む (`setup  21% · Opus 5 · 12m`)。1 つだけのときは従来の詳細レイアウトのまま
- **同名プロジェクトの区別** — 同じリポジトリの worktree を複数開くとラベルが衝突するため、その場合だけブランチ名を添える
- **文脈上限をモデル別に** — 現行モデルで 200k なのは Haiku 4.5 だけで、Claude 5 系 (Opus / Sonnet / Fable) はいずれも 1M が既定 (ベータヘッダも長文脈の追加料金も無い)。100% 超えの表示が直る
- **worktree のプロジェクト名** — worktree の中では cwd 末尾が worktree 名になりどのリポジトリか分からなくなっていたので、元のリポジトリ名を出す
- **カード幅の抑制** — 幅は一番長い行に引きずられるため、プロジェクト名・ブランチ名・セッション名を表示幅 28 (全角は 2 幅) で切り詰める

## 確認方法

```bash
python3 claude/tests/runcat_metrics_test.py
```

34 件 green。新しいテストは複数セッション集約・TTL・幅の切り詰め・文脈上限・worktree 判定・session_id のサニタイズそれぞれについて、実装を一時的に壊して赤くなることを確認してから仕上げた。

実データでも検証済み。実際の transcript 4 本で hook モードを走らせた結果:

```
divive · claude/uni…   21.7% · Opus 5 · high
calverge               45.5% · Opus 5 · xhigh · 11h13m
.setup                 52.8% · Opus 5 · high · 47m
divive · claude/mac…   19.4% · Opus 5 · high
```

4 セッションが正しいリポジトリ名で並び、同名の `divive` は自動でブランチ付きになる。単一セッション時の Context は実測 18.8% (`187.6k/1M`) と妥当な値になった。

## 残る制約 (このPRの対象外)

`5h` / `7d` / `Cost` / `Edits` は hook モードでは依然出せない。公式ドキュメントで hook 入力に `rate_limits` / `cost` / `context_window` が含まれないことを確認し、無関係な 3 セッション分の transcript JSONL も走査して構造化されたレート制限が記録されていないことを確認した。`5h` / `7d` はターミナルの `claude` を一度対話起動して控え (`~/.claude/runcat-rate-limits.json`) を作れば、以後デスクトップアプリでも `≥23%` 形式で出る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)