### PR TITLE
feat(claude): RunCat のカードを常に一覧形式にする

### DIFF
--- a/claude/runcat-metrics.py
+++ b/claude/runcat-metrics.py
@@ -25,25 +25,21 @@ RunCat Neo の Custom Metrics 形式
 (最終更新が SESSION_TTL_SECONDS 以内) を読み直してカードを組む。これで最後に走った
 セッションが他を上書きしてしまうことがなくなる。
 
-カードの形は生きているセッション数で変わる:
+カードはセッション数によらず同じ形をとる。行が増減して見た目が変わらない方が
+一覧として読みやすいため:
 
-  1 つ  → そのセッションの詳細を 1 行 1 項目で出す (下表)
-  2 つ+ → レート制限を頭に置き、以降はセッションごとに 1 行へ畳む
-          (例: `setup   21% · Opus 5 · 12m`)。行数とカード幅を抑えるため。
+    5h        23.5% · 2h41m left     レート制限 (取れたときだけ)
+    7d        41.2% · 3d4h left
+    setup     21% · Opus 5 · 12m     ここから下はセッションごとに 1 行
+    divive    8% · Opus 5 · 3m
 
-詳細レイアウトで出る行 (値が取れない行は出さない。◯=そのモードで取れる):
+セッション行のラベルはプロジェクト名。同じプロジェクトが複数あるときだけ
+ブランチ名を添えて区別する。値に入れられるもの (◯=そのモードで取れる):
 
-    行       例                                 statusLine  hook
-    Model    Opus 5 · xhigh · think · fast          ◯    ◯ (think/fast は無し)
-    Context  31% · 62.5k/200k                       ◯    ◯ (上限は推定値)
-    5h / 7d  23.5% · 2h41m left                     ◯    △ (statusLine の控えを使う)
-    Cost     $0.42                                  ◯    ✗ (hook 入力に無い。トークン単価も持たない)
-    Elapsed  45m · API 2m18s                        ◯    ◯ (API 時間は無し)
-    Edits    +156 / -23                             ◯    ✗
-    Project  setup · feature-xyz                    ◯    ◯ (worktree 名でなくブランチ名)
-    Session  my-session                             ◯    ◯
-    Agent    security-reviewer                      ◯    ✗
-    PR       #1234 · pending                        ◯    ◯ (レビュー状態は無し)
+    項目      例                       statusLine  hook
+    使用率    21%                          ◯    ◯ (上限はモデル名から引く)
+    モデル    Opus 5 · xhigh · think       ◯    ◯ (think/fast は無し)
+    経過      12m                          ◯    ◯
 
 メニューバーへ出す値 (metricsBarValue) は週間制限の使用率。
 
@@ -56,12 +52,14 @@ five_hour と seven_day だけのため出せない (2.1.212 時点)。
 文脈の上限は statusLine 入力にしか無い。hook モードではモデル名から引く
 (200k なのは Haiku 4.5 だけで、Claude 5 系はいずれも 1M が既定)。
 
-カードの幅は一番長い行に引きずられるので、可変長の値 (プロジェクト名・ブランチ名・
-セッション名) は MAX_VALUE_WIDTH 幅で切り詰める。
+カードの幅は一番長い行に引きずられるので、可変長の値 (プロジェクト名・ブランチ名)
+は MAX_VALUE_WIDTH 幅で切り詰める。
 
-意図的に出していないもの: session_id・prompt_id・transcript_path・cwd (カード向きでない
-ID / パス)、version・output_style.name・vim.mode (常時見る価値が薄い)、
-exceeds_200k_tokens (Context 行と重複。1M コンテキストのモデルでのみ差が出る)。
+一覧に絞ったため、statusLine では取れるが出していないものがある: cost・
+total_lines_added/removed・pr・agent.name・session_name (1 行に畳むと長くなる)。
+ほかに session_id・prompt_id・transcript_path・cwd (カード向きでない ID / パス)、
+version・output_style.name・vim.mode (常時見る価値が薄い)、exceeds_200k_tokens
+(使用率と重複)。必要になったらセッション行の値へ足す。
 
 環境変数 RUNCAT_OUT_FILE で出力先を上書きできる (既定: ~/.claude/runcat-usage.json)。
 レート制限の控えとセッションごとの状態は同じディレクトリに置く。
@@ -100,8 +98,12 @@ DEFAULT_CONTEXT_WINDOW = 1_000_000
 # transcript は伸び続けるので末尾のこのサイズだけ読む (毎ツール呼び出しで走るため)
 TRANSCRIPT_TAIL_BYTES = 256 * 1024
 
-# 可変長の値をこの表示幅で切る (全角は 2 幅)。カードが横に伸びるのを防ぐ
-MAX_VALUE_WIDTH = 28
+# 可変長の値をこの表示幅で切る (全角は 2 幅)。カードが横に伸びるのを防ぐ。
+# `45.5% · Opus 5 · xhigh · 11h13m` のような一番長い形がちょうど収まる幅
+MAX_VALUE_WIDTH = 32
+
+# セッション行のラベル (プロジェクト名) をこの表示幅で切る
+MAX_LABEL_WIDTH = 20
 
 
 # --- 整形ヘルパー -------------------------------------------------------------
@@ -142,7 +144,7 @@ def clip(text, limit=MAX_VALUE_WIDTH):
             break
         kept.append(char)
         width += char_width
-    return "".join(kept).rstrip() + "…"
+    return "".join(kept).rstrip(" ·") + "…"  # 途中で切れた区切りは残さない
 
 
 def row(title, formatted, normalized=None):
@@ -340,54 +342,58 @@ def load_sessions(now_epoch, current_id=None):
 
 
 def session_label(state, states):
-    """セッション行のラベル。同じプロジェクトが複数あるときだけブランチを添える。"""
-    project = state.get("project") or state.get("title") or "session"
-    same = [s for s in states if (s.get("project") or s.get("title")) == project]
-    if len(same) > 1 and state.get("branch"):
-        project = f"{project} · {state['branch']}"
-    return clip(project, 20)
+    """セッション行のラベル。
+
+    一覧ではラベルが唯一の手掛かりなので、同じものが並ばないよう必要な分だけ
+    細かくする: プロジェクト名 → ブランチを添える → 同じ worktree で複数開いて
+    いるならセッション名。幅が限られるので、区別に要る分しか足さない。
+    """
+    def base(s):
+        return s.get("project") or s.get("title") or "session"
+
+    label = base(state)
+    same = [s for s in states if base(s) == label]
+    if len(same) <= 1:
+        return clip(label, MAX_LABEL_WIDTH)
+
+    branch = state.get("branch")
+    if not branch:
+        return clip(label, MAX_LABEL_WIDTH)
+    if sum(1 for s in same if s.get("branch") == branch) <= 1:
+        return clip(f"{label} · {branch}", MAX_LABEL_WIDTH)
+    # プロジェクトもブランチも同じ。残る手掛かりはセッション名だけ
+    return clip(state.get("title") or f"{label} · {branch}", MAX_LABEL_WIDTH)
+
+
+def head(value, keep):
+    """` · ` 区切りの値から先頭 keep 個だけ残す。
+
+    Model は `Opus 5 · xhigh · think · fast`、Elapsed は `45m · API 2m18s` の
+    ように詳細が続く。1 行へ畳むと長すぎるので、一覧では頭だけ使う。
+    """
+    parts = [p for p in str(value or "").split(" · ") if p]
+    return " · ".join(parts[:keep]) or None
 
 
 def session_summary(state):
     """セッション行の値。使用率・モデル・経過を 1 行へ畳む。"""
-    parts = []
     ctx_pct = num(state.get("ctx_pct"))
-    if ctx_pct is not None:
-        parts.append(f"{ctx_pct:g}%")
-    if state.get("model"):
-        parts.append(str(state["model"]))
-    if state.get("elapsed"):
-        parts.append(str(state["elapsed"]))
-    return " · ".join(parts) or None
+    parts = [
+        f"{round(ctx_pct, 1):g}%" if ctx_pct is not None else None,  # 一覧では小数第 1 位で十分
+        head(state.get("model"), 2),   # モデル名と effort まで
+        head(state.get("elapsed"), 1),  # API 時間は落とす
+    ]
+    return clip(" · ".join(p for p in parts if p)) or None
 
 
 # --- カードの組み立て -----------------------------------------------------------
 
-def detail_metrics(state, limits, now_epoch, stale):
-    """セッションが 1 つのときのレイアウト (1 行 1 項目)。"""
-    ctx_pct = num(state.get("ctx_pct"))
-    ctx_row = None
-    if ctx_pct is not None:
-        ctx_row = context_row(state.get("ctx_used"), state.get("ctx_size"), ctx_pct)
-    project = state.get("project")
-    branch = state.get("branch")
-    return [
-        row("Model", state.get("model")),
-        ctx_row,
-        rate_limit_row("5h", limits.get("five_hour", {}), now_epoch, stale=stale),
-        rate_limit_row("7d", limits.get("seven_day", {}), now_epoch, stale=stale),
-        row("Cost", state.get("cost")),
-        row("Elapsed", state.get("elapsed")),
-        row("Edits", state.get("edits")),
-        row("Project", clip(f"{project} · {branch}" if project and branch else (project or branch))),
-        row("Session", clip(state.get("title"))),
-        row("Agent", clip(state.get("agent"))),
-        row("PR", state.get("pr")),
-    ]
+def build_card(states, limits, now_epoch, stale):
+    """生きているセッションからカードを組む。
 
-
-def summary_metrics(states, limits, now_epoch, stale):
-    """セッションが複数のときのレイアウト (レート制限 + 1 セッション 1 行)。"""
+    レート制限を頭に置き、以降はセッションごとに 1 行。セッション数によらず
+    同じ形にすることで、行が増減して見た目が変わらないようにしている。
+    """
     metrics = [
         rate_limit_row("5h", limits.get("five_hour", {}), now_epoch, stale=stale),
         rate_limit_row("7d", limits.get("seven_day", {}), now_epoch, stale=stale),
@@ -399,16 +405,6 @@ def summary_metrics(states, limits, now_epoch, stale):
             session_summary(state),
             ctx_pct / 100 if ctx_pct is not None else None,
         ))
-    return metrics
-
-
-def build_card(states, limits, now_epoch, stale):
-    """生きているセッションからカードを組む。"""
-    if len(states) <= 1:
-        state = states[0] if states else {}
-        metrics = detail_metrics(state, limits, now_epoch, stale)
-    else:
-        metrics = summary_metrics(states, limits, now_epoch, stale)
     return snapshot(metrics, fmt_bar_value(limits.get("seven_day", {}), stale=stale))
 
 

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -18,12 +18,16 @@ from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent.parent / "runcat-metrics.py"
 
+# カード上部に固定で並ぶレート制限の行。残りがセッション行
+LIMIT_TITLES = ("5h", "7d")
+
 
 class ScriptTestCase(unittest.TestCase):
     def run_script(self, stdin_text, workdir=None):
         """stdin を流してスクリプトを実行し、(スナップショット, stdout) を返す。
 
-        workdir を渡すと出力先を共有できる (レート制限の控えを跨ぐ実行の検証用)。
+        workdir を渡すと出力先を共有できる (レート制限の控えやセッション状態を
+        跨ぐ実行の検証用)。
         """
         if workdir is not None:
             return self.run_script_in(stdin_text, Path(workdir))
@@ -44,6 +48,16 @@ class ScriptTestCase(unittest.TestCase):
 
     def rows(self, snapshot):
         return {m["title"]: m for m in snapshot["metrics"]}
+
+    def sessions(self, snapshot):
+        """レート制限を除いた行 = セッション行 (カードに並ぶ順)。"""
+        return [m for m in snapshot["metrics"] if m["title"] not in LIMIT_TITLES]
+
+    def only_session(self, snapshot):
+        """セッションが 1 つである前提で、その行を返す。"""
+        rows = self.sessions(snapshot)
+        self.assertEqual(len(rows), 1, f"セッション行が 1 つではない: {rows}")
+        return rows[0]
 
     def run_hook(self, entries, event="Stop", workdir=None):
         """transcript JSONL を作り、hook 入力を流してスナップショットを返す。"""
@@ -84,9 +98,10 @@ class ScriptTestCase(unittest.TestCase):
 class StatusLineModeTest(ScriptTestCase):
     """ターミナルの statusLine から呼ばれる経路。"""
 
-    def test_full_payload_renders_every_row(self):
+    def test_full_payload_renders_the_session_row(self):
         now = int(time.time())
         payload = {
+            "session_id": "s1",
             "model": {"id": "claude-opus-4-8", "display_name": "Opus 4.8"},
             "session_name": "runcat-metrics",
             "workspace": {
@@ -123,28 +138,26 @@ class StatusLineModeTest(ScriptTestCase):
 
         self.assertEqual(stdout, "Opus 4.8")
         self.assertEqual(snapshot["title"], "Claude Code")
-        # メニューバーへ出すのは週間制限の使用率 (整数へ丸める)
-        self.assertEqual(snapshot["metricsBarValue"], "41%")
-        self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · xhigh · think · fast")
-        self.assertEqual(rows["Context"]["formattedValue"], "31.35% · 62.7k/200k")
-        self.assertAlmostEqual(rows["Context"]["normalizedValue"], 0.3135)
+        # レート制限が先頭 2 行、その下がセッション行
+        self.assertEqual([m["title"] for m in snapshot["metrics"]][:2], ["5h", "7d"])
         self.assertEqual(rows["5h"]["formattedValue"], "23.5% · 2h41m left")
         self.assertEqual(rows["7d"]["formattedValue"], "41.2% · 3d4h left")
-        self.assertEqual(rows["Cost"]["formattedValue"], "$12.35")
-        self.assertEqual(rows["Elapsed"]["formattedValue"], "1h15m · API 2m")
-        self.assertEqual(rows["Edits"]["formattedValue"], "+156 / -23")
-        self.assertEqual(rows["Project"]["formattedValue"], "setup · feature-xyz")
-        self.assertEqual(rows["Session"]["formattedValue"], "runcat-metrics")
-        self.assertEqual(rows["Agent"]["formattedValue"], "security-reviewer")
-        self.assertEqual(rows["PR"]["formattedValue"], "#1234 · pending")
-        # 進捗バーは割合を持つ行にだけ付く
-        self.assertNotIn("normalizedValue", rows["Model"])
-        self.assertNotIn("normalizedValue", rows["Cost"])
+        # メニューバーへ出すのは週間制限の使用率 (整数へ丸める)
+        self.assertEqual(snapshot["metricsBarValue"], "41%")
 
-    def test_empty_payload_falls_back_to_model_row_only(self):
+        session = self.only_session(snapshot)
+        self.assertEqual(session["title"], "setup")
+        # 使用率 · モデルと effort · 経過。think/fast と API 時間は一覧では落とす
+        self.assertEqual(session["formattedValue"], "31.4% · Opus 4.8 · xhigh · 1h15m")
+        self.assertAlmostEqual(session["normalizedValue"], 0.3135)
+
+    def test_empty_payload_still_renders_one_session(self):
         snapshot, stdout = self.run_script("{}")
         self.assertEqual(stdout, "Claude Code")
-        self.assertEqual([m["title"] for m in snapshot["metrics"]], ["Model"])
+        session = self.only_session(snapshot)
+        # プロジェクト名もセッション名も無いときのラベル
+        self.assertEqual(session["title"], "session")
+        self.assertEqual(session["formattedValue"], "Claude Code")
         self.assertNotIn("metricsBarValue", snapshot)
 
     def test_malformed_stdin_does_not_crash(self):
@@ -152,7 +165,7 @@ class StatusLineModeTest(ScriptTestCase):
             with self.subTest(stdin=stdin_text):
                 snapshot, stdout = self.run_script(stdin_text)
                 self.assertEqual(stdout, "Claude Code")
-                self.assertEqual(self.rows(snapshot)["Model"]["formattedValue"], "Claude Code")
+                self.assertEqual(self.only_session(snapshot)["formattedValue"], "Claude Code")
 
     def test_wrong_types_are_ignored_instead_of_rendered(self):
         payload = {
@@ -164,8 +177,8 @@ class StatusLineModeTest(ScriptTestCase):
             "fast_mode": "yes",  # true でなければマーカーを出さない
         }
         snapshot, _ = self.run_script(json.dumps(payload))
-        self.assertEqual([m["title"] for m in snapshot["metrics"]], ["Model"])
-        self.assertEqual(self.rows(snapshot)["Model"]["formattedValue"], "Claude Code")
+        self.assertEqual([m["title"] for m in snapshot["metrics"]], ["session"])
+        self.assertEqual(self.only_session(snapshot)["formattedValue"], "Claude Code")
 
     def test_expired_reset_and_over_limit_percentage(self):
         payload = {"rate_limits": {"five_hour": {"used_percentage": 150, "resets_at": 1}}}
@@ -182,21 +195,20 @@ class StatusLineModeTest(ScriptTestCase):
             "total_output_tokens": 1_500, "context_window_size": 1_000_000,
         }}
         snapshot, _ = self.run_script(json.dumps(payload))
-        self.assertEqual(self.rows(snapshot)["Context"]["formattedValue"], "8.4% · 84.5k/1M")
+        self.assertEqual(self.only_session(snapshot)["formattedValue"], "8.4% · Claude Code")
 
     def test_project_falls_back_to_directory_name(self):
         payload = {"workspace": {"project_dir": "/Users/so/foo/"}, "worktree": {"name": "my-feature"}}
         snapshot, _ = self.run_script(json.dumps(payload))
-        self.assertEqual(self.rows(snapshot)["Project"]["formattedValue"], "foo · my-feature")
+        # 同名プロジェクトが他に無いので worktree 名は添えない
+        self.assertEqual(self.only_session(snapshot)["title"], "foo")
 
     def test_zero_values_are_rendered_not_dropped(self):
-        payload = {"cost": {"total_cost_usd": 0, "total_lines_added": 0, "total_lines_removed": 0},
-                   "context_window": {"used_percentage": 0}}
+        payload = {"context_window": {"used_percentage": 0}}
         snapshot, _ = self.run_script(json.dumps(payload))
-        rows = self.rows(snapshot)
-        self.assertEqual(rows["Cost"]["formattedValue"], "$0.00")
-        self.assertEqual(rows["Edits"]["formattedValue"], "+0 / -0")
-        self.assertEqual(rows["Context"]["formattedValue"], "0%")
+        session = self.only_session(snapshot)
+        self.assertEqual(session["formattedValue"], "0% · Claude Code")
+        self.assertEqual(session["normalizedValue"], 0.0)
 
     def test_snapshot_is_valid_custom_metrics_schema(self):
         snapshot, _ = self.run_script('{"model": {"display_name": "Opus 4.8"}}')
@@ -233,25 +245,20 @@ class StatusLineModeTest(ScriptTestCase):
 class HookModeTest(ScriptTestCase):
     """hook から呼ばれる経路 (デスクトップアプリではこちらだけが動く)。"""
 
-    def test_transcript_renders_available_rows(self):
+    def test_transcript_renders_the_session_row(self):
         snapshot = self.run_hook([
             {"type": "user", "timestamp": "2026-07-23T08:48:54.157Z", "cwd": "/Users/so/.setup"},
             {"type": "custom-title", "customTitle": "RunCat 連携"},
             {"type": "pr-link", "prNumber": 23, "prRepository": "shinyaoguri/setup"},
             self.assistant_entry(),
         ])
-        rows = self.rows(snapshot)
-        self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
+        session = self.only_session(snapshot)
+        self.assertEqual(session["title"], "setup")
         # Opus は 1M 文脈。142,548 / 1M = 14.2548% → 小数第 1 位へ丸める
-        self.assertEqual(rows["Context"]["formattedValue"], "14.3% · 142.5k/1M")
-        self.assertEqual(rows["Elapsed"]["formattedValue"], "30m")
-        # 28 幅を超える値は切り詰める (カードが横に伸びるのを防ぐ)
-        self.assertEqual(rows["Project"]["formattedValue"], "setup · feat/runcat-metrics…")
-        self.assertEqual(rows["Session"]["formattedValue"], "RunCat 連携")
-        self.assertEqual(rows["PR"]["formattedValue"], "#23")
-        # hook 入力からは取れない行は出さない (5h / 7d は控えが無ければ同様)
-        for absent in ("5h", "7d", "Cost", "Edits", "Agent"):
-            self.assertNotIn(absent, rows)
+        self.assertEqual(session["formattedValue"], "14.3% · Opus 4.8 · high · 30m")
+        # hook 入力からは取れないレート制限は出さない (控えが無ければ同様)
+        for absent in LIMIT_TITLES:
+            self.assertNotIn(absent, self.rows(snapshot))
         self.assertNotIn("metricsBarValue", snapshot)
 
     def test_model_id_is_prettified(self):
@@ -264,26 +271,27 @@ class HookModeTest(ScriptTestCase):
             with self.subTest(model_id=model_id):
                 snapshot = self.run_hook([self.assistant_entry(
                     message={"model": model_id, "usage": {}}, effort=None)])
-                self.assertEqual(self.rows(snapshot)["Model"]["formattedValue"], expected)
+                # エントリが 1 つだけなので経過は 0s。使用率は usage が空で出ない
+                self.assertEqual(
+                    self.only_session(snapshot)["formattedValue"], f"{expected} · 0s")
 
     def test_worktree_cwd_falls_back_to_the_repository_name(self):
         """worktree の中では末尾が worktree 名になるので、元のリポジトリ名を出す。"""
         snapshot = self.run_hook([self.assistant_entry(
             cwd="/Users/so/Repos/myapp/.claude/worktrees/feat-something-250692",
             gitBranch="feat/something")])
-        self.assertEqual(
-            self.rows(snapshot)["Project"]["formattedValue"], "myapp · feat/something")
+        self.assertEqual(self.only_session(snapshot)["title"], "myapp")
 
     def test_sidechain_entries_are_ignored(self):
         """サブエージェント (isSidechain) の usage は本セッションの文脈量ではない。"""
         snapshot = self.run_hook([
+            {"type": "user", "timestamp": "2026-07-23T08:48:54.157Z", "cwd": "/Users/so/.setup"},
             self.assistant_entry(),
             self.assistant_entry(isSidechain=True, message={
                 "model": "claude-haiku-4-5", "usage": {"input_tokens": 10, "output_tokens": 5}}),
         ])
-        rows = self.rows(snapshot)
-        self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
-        self.assertEqual(rows["Context"]["formattedValue"], "14.3% · 142.5k/1M")
+        self.assertEqual(
+            self.only_session(snapshot)["formattedValue"], "14.3% · Opus 4.8 · high · 30m")
 
     def test_broken_transcript_lines_are_skipped(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -295,7 +303,7 @@ class HookModeTest(ScriptTestCase):
             snapshot, stdout = self.run_script(json.dumps({
                 "hook_event_name": "Stop", "transcript_path": str(transcript)}))
             self.assertEqual(stdout, "")
-            self.assertEqual(self.rows(snapshot)["Model"]["formattedValue"], "Opus 4.8 · high")
+            self.assertIn("Opus 4.8", self.only_session(snapshot)["formattedValue"])
 
     def test_huge_transcript_reads_only_the_tail(self):
         """毎ツール呼び出しで走るため、巨大な transcript でも末尾しか読まない。"""
@@ -305,10 +313,10 @@ class HookModeTest(ScriptTestCase):
                   for _ in range(400)]  # 800KB 超 > TRANSCRIPT_TAIL_BYTES (256KB)
         start = {"type": "user", "timestamp": "2026-07-23T08:48:54.157Z", "cwd": "/Users/so/.setup"}
         snapshot = self.run_hook([start] + filler + [self.assistant_entry()])
-        rows = self.rows(snapshot)
-        self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
         # 先頭行だけは別途読むので、セッション開始からの経過時間になる (末尾からなら 9m)
-        self.assertEqual(rows["Elapsed"]["formattedValue"], "30m")
+        self.assertTrue(
+            self.only_session(snapshot)["formattedValue"].endswith("30m"),
+            self.only_session(snapshot)["formattedValue"])
 
     def test_missing_transcript_does_not_fail_the_hook(self):
         """hook を止めないため、transcript が読めなくても異常終了しない。"""
@@ -362,8 +370,8 @@ class RateLimitCacheTest(ScriptTestCase):
             self.assertEqual(rows["5h"]["formattedValue"], "≥23.5% · 2h41m left")
             self.assertEqual(rows["7d"]["formattedValue"], "≥41.2% · 3d4h left")
             self.assertEqual(snapshot["metricsBarValue"], "≥41%")
-            # 控えを使っても他の行は transcript 由来のまま
-            self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
+            # 控えを使ってもセッション行は transcript 由来のまま
+            self.assertIn("Opus 4.8", self.only_session(snapshot)["formattedValue"])
 
     def test_reset_windows_are_not_reused(self):
         """リセット済みのウィンドウの使用率はもう当てにならないので出さない。"""
@@ -391,7 +399,8 @@ class RateLimitCacheTest(ScriptTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             self.run_script(self.statusline_payload(
                 seven_day={"used_percentage": 41.2, "resets_at": now + 273_600 + 30}), workdir=tmpdir)
-            self.run_script('{"model": {"display_name": "Opus 4.8"}}', workdir=tmpdir)
+            self.run_script('{"session_id": "abc123", "model": {"display_name": "Opus 4.8"}}',
+                            workdir=tmpdir)
             self.assertEqual(self.cache(tmpdir)["seven_day"]["used_percentage"], 41.2)
             self.assertIn("7d", self.rows(self.run_hook([self.assistant_entry()], workdir=tmpdir)))
 
@@ -399,9 +408,8 @@ class RateLimitCacheTest(ScriptTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             (Path(tmpdir) / self.CACHE_NAME).write_text("{ truncated", encoding="utf-8")
             snapshot = self.run_hook([self.assistant_entry()], workdir=tmpdir)
-            rows = self.rows(snapshot)
-            self.assertEqual(rows["Model"]["formattedValue"], "Opus 4.8 · high")
-            self.assertNotIn("5h", rows)
+            self.assertIn("Opus 4.8", self.only_session(snapshot)["formattedValue"])
+            self.assertNotIn("5h", self.rows(snapshot))
 
 
 class MultiSessionTest(ScriptTestCase):
@@ -443,20 +451,15 @@ class MultiSessionTest(ScriptTestCase):
             self.assertEqual(rows["setup"]["formattedValue"], "21% · Opus 5 · 1h15m")
             self.assertEqual(rows["divive"]["formattedValue"], "8% · Opus 5 · 3m")
             self.assertAlmostEqual(rows["setup"]["normalizedValue"], 0.21)
-            # 畳んだので 1 項目 1 行の詳細レイアウトは出さない
-            for absent in ("Model", "Context", "Project", "Elapsed"):
-                self.assertNotIn(absent, rows)
 
-    def test_single_session_keeps_the_detail_layout(self):
-        """1 つだけのときは畳まず詳細を出す (情報量を落とさない)。"""
+    def test_a_single_session_uses_the_same_layout(self):
+        """セッションが 1 つでも形を変えない (行が増減して見た目が動かないように)。"""
         with tempfile.TemporaryDirectory() as tmpdir:
             snapshot, _ = self.run_script(
                 self.statusline_payload("s1", "setup", 21, 4_500_000), workdir=tmpdir)
-            rows = self.rows(snapshot)
-            self.assertEqual(rows["Model"]["formattedValue"], "Opus 5")
-            self.assertEqual(rows["Context"]["formattedValue"], "21%")
-            self.assertEqual(rows["Project"]["formattedValue"], "setup")
-            self.assertNotIn("setup", rows)
+            self.assertEqual([m["title"] for m in snapshot["metrics"]], ["setup"])
+            self.assertEqual(
+                self.rows(snapshot)["setup"]["formattedValue"], "21% · Opus 5 · 1h15m")
 
     def test_stale_sessions_are_dropped(self):
         """終了したセッションはカードに残さない (更新が途絶えたら畳む)。"""
@@ -465,10 +468,7 @@ class MultiSessionTest(ScriptTestCase):
             self.age_session(tmpdir, 31 * 60)  # SESSION_TTL_SECONDS (30 分) 超え
             snapshot, _ = self.run_script(
                 self.statusline_payload("s2", "divive", 8, 180_000), workdir=tmpdir)
-            rows = self.rows(snapshot)
-            # 生きているのは s2 だけなので詳細レイアウトに戻る
-            self.assertEqual(rows["Project"]["formattedValue"], "divive")
-            self.assertNotIn("setup", rows)
+            self.assertEqual([m["title"] for m in self.sessions(snapshot)], ["divive"])
 
     def test_same_project_rows_are_told_apart_by_branch(self):
         """同じリポジトリの worktree を 2 つ開くとラベルが衝突するのでブランチを添える。"""
@@ -481,8 +481,32 @@ class MultiSessionTest(ScriptTestCase):
             self.assertIn("setup · feat/a", rows)
             self.assertIn("setup · feat/b", rows)
 
-    def test_rate_limits_lead_the_folded_card(self):
-        """畳んだ形でもレート制限は主役のまま先頭に置く。"""
+    def test_same_branch_rows_fall_back_to_the_session_name(self):
+        """同じ worktree で 2 つ開くとブランチでも区別できないので、セッション名で分ける。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for session_id, title in (("s1", "レビューの続き"), ("s2", "テスト追加")):
+                payload = json.loads(
+                    self.statusline_payload(session_id, "setup", 21, 60_000, branch="main"))
+                payload["session_name"] = title
+                self.run_script(json.dumps(payload), workdir=tmpdir)
+            snapshot, _ = self.run_script(json.dumps(payload), workdir=tmpdir)
+            labels = [m["title"] for m in self.sessions(snapshot)]
+            self.assertEqual(sorted(labels), ["テスト追加", "レビューの続き"])
+
+    def test_session_name_is_only_used_when_the_branch_collides(self):
+        """ブランチで区別できるならセッション名は使わない (ラベルを短く保つ)。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for session_id, branch in (("s1", "feat/a"), ("s2", "feat/b")):
+                payload = json.loads(
+                    self.statusline_payload(session_id, "setup", 21, 60_000, branch=branch))
+                payload["session_name"] = "使わないはずの名前"
+                self.run_script(json.dumps(payload), workdir=tmpdir)
+            snapshot, _ = self.run_script(json.dumps(payload), workdir=tmpdir)
+            labels = [m["title"] for m in self.sessions(snapshot)]
+            self.assertEqual(sorted(labels), ["setup · feat/a", "setup · feat/b"])
+
+    def test_rate_limits_lead_the_card(self):
+        """レート制限は主役なので常に先頭に置く。"""
         now = int(time.time())
         with tempfile.TemporaryDirectory() as tmpdir:
             self.run_script(self.statusline_payload("s1", "setup", 21, 60_000), workdir=tmpdir)
@@ -513,36 +537,53 @@ class MultiSessionTest(ScriptTestCase):
 
 
 class DisplayWidthTest(ScriptTestCase):
-    """カード幅は一番長い行に引きずられるため、可変長の値は切り詰める。"""
+    """カード幅は一番長い行に引きずられるため、ラベルと値を切り詰める。"""
 
     def width(self, text):
         return sum(2 if unicodedata.east_asian_width(c) in "WF" else 1 for c in text)
 
-    def test_long_values_are_clipped(self):
+    def test_long_labels_are_clipped(self):
         payload = {
-            "session_name": "アドオンのプロダクション対応レビューと後片付け",
-            "workspace": {
-                "repo": {"name": "setup"},
-                "git_worktree": "global-claude-md-symlinks-250692",
-            },
+            "workspace": {"repo": {"name": "global-claude-md-symlinks-250692"}},
         }
         snapshot, _ = self.run_script(json.dumps(payload))
-        rows = self.rows(snapshot)
-        # 全角は 2 幅として数える (28 幅 = 全角 14 文字 / 半角 28 文字)
-        self.assertEqual(rows["Session"]["formattedValue"], "アドオンのプロダクション対…")
-        self.assertEqual(rows["Project"]["formattedValue"], "setup · global-claude-md-sy…")
-        for title in ("Session", "Project"):
-            self.assertLessEqual(self.width(rows[title]["formattedValue"]), 28)
+        # ラベルは 20 幅まで
+        self.assertEqual(self.only_session(snapshot)["title"], "global-claude-md-sy…")
+        self.assertLessEqual(self.width(self.only_session(snapshot)["title"]), 20)
+
+    def test_long_values_are_clipped(self):
+        payload = {
+            "model": {"display_name": "Some Very Long Model Name Indeed"},
+            "workspace": {"repo": {"name": "setup"}},
+            "context_window": {"used_percentage": 21},
+            "effort": {"level": "xhigh"},
+        }
+        snapshot, _ = self.run_script(json.dumps(payload))
+        value = self.only_session(snapshot)["formattedValue"]
+        self.assertLessEqual(self.width(value), 32)
+        self.assertTrue(value.endswith("…"), value)
+        # 先頭の使用率は必ず読める
+        self.assertTrue(value.startswith("21% · "), value)
+
+    def test_full_width_labels_count_as_two(self):
+        payload = {"session_name": "アドオンのプロダクション対応レビューと後片付け"}
+        snapshot, _ = self.run_script(json.dumps(payload))
+        # プロジェクト名が無ければセッション名をラベルにする。全角は 2 幅 (20 幅 = 全角 10 文字)
+        self.assertEqual(self.only_session(snapshot)["title"], "アドオンのプロダク…")
+        self.assertLessEqual(self.width(self.only_session(snapshot)["title"]), 20)
 
     def test_short_values_are_left_alone(self):
-        payload = {"session_name": "runcat", "workspace": {"repo": {"name": "setup"}}}
-        rows = self.rows(self.run_script(json.dumps(payload))[0])
-        self.assertEqual(rows["Session"]["formattedValue"], "runcat")
-        self.assertEqual(rows["Project"]["formattedValue"], "setup")
+        payload = {"workspace": {"repo": {"name": "setup"}}, "model": {"display_name": "Opus 5"}}
+        snapshot, _ = self.run_script(json.dumps(payload))
+        self.assertEqual(self.only_session(snapshot)["title"], "setup")
+        self.assertEqual(self.only_session(snapshot)["formattedValue"], "Opus 5")
 
 
 class ContextWindowTest(ScriptTestCase):
     """hook 入力には文脈の上限が無いので、モデル名から引く。"""
+
+    # 経過時間を既存テストと揃えるための開始エントリ (これが無いと 0s になる)
+    START = {"type": "user", "timestamp": "2026-07-23T08:48:54.157Z", "cwd": "/Users/so/.setup"}
 
     def usage_entry(self, model, cache_read):
         return self.assistant_entry(message={"model": model, "usage": {
@@ -552,23 +593,27 @@ class ContextWindowTest(ScriptTestCase):
 
     def test_claude_5_models_get_the_1m_window(self):
         """Opus / Sonnet / Fable 5 はいずれも 1M が既定 (ベータヘッダ不要)。"""
-        for model in ("claude-opus-5", "claude-sonnet-5", "claude-fable-5"):
+        for model, name in (("claude-opus-5", "Opus 5"), ("claude-sonnet-5", "Sonnet 5"),
+                            ("claude-fable-5", "Fable 5")):
             with self.subTest(model=model):
-                rows = self.rows(self.run_hook([self.usage_entry(model, 411_465)]))
+                snapshot = self.run_hook([self.START, self.usage_entry(model, 411_465)])
+                session = self.only_session(snapshot)
                 # 415,600 / 1M = 41.56% → 小数第 1 位へ丸める
-                self.assertEqual(rows["Context"]["formattedValue"], "41.6% · 415.6k/1M")
-                self.assertAlmostEqual(rows["Context"]["normalizedValue"], 0.416)
+                self.assertEqual(session["formattedValue"], f"41.6% · {name} · high · 30m")
+                self.assertAlmostEqual(session["normalizedValue"], 0.416)
 
     def test_haiku_gets_the_200k_window(self):
         """現行モデルで 200k なのは Haiku 4.5 だけ。"""
-        rows = self.rows(self.run_hook([self.usage_entry("claude-haiku-4-5-20251001", 138_413)]))
-        self.assertEqual(rows["Context"]["formattedValue"], "71.3% · 142.5k/200k")
+        snapshot = self.run_hook([self.START, self.usage_entry("claude-haiku-4-5-20251001", 138_413)])
+        self.assertEqual(
+            self.only_session(snapshot)["formattedValue"], "71.3% · Haiku 4.5 · high · 30m")
 
     def test_usage_above_the_known_window_does_not_exceed_100_percent(self):
         """表に無い上限のモデルでも 100% 超えの表示にはしない。"""
-        rows = self.rows(self.run_hook([self.usage_entry("claude-haiku-4-5", 411_465)]))
-        self.assertEqual(rows["Context"]["formattedValue"], "100% · 415.6k/415.6k")
-        self.assertEqual(rows["Context"]["normalizedValue"], 1.0)
+        snapshot = self.run_hook([self.START, self.usage_entry("claude-haiku-4-5", 411_465)])
+        session = self.only_session(snapshot)
+        self.assertTrue(session["formattedValue"].startswith("100% · "), session["formattedValue"])
+        self.assertEqual(session["normalizedValue"], 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 目的

「個別のコンテキストの一覧」「5時間制限」「週間制限」を一望したい、というご要望に合わせてレイアウトを 1 つに統一する。

これまではセッションが 1 つのときだけ 1 行 1 項目の詳細表示、2 つ以上で一覧へ切り替わる作りだった。セッションの増減でカードの見た目が大きく動くうえ、一覧が主目的なら詳細表示は不要なため。

```
5h        23.5% · 2h41m left
7d        41.2% · 3d4h left
setup     21% · Opus 5 · 12m
divive    8% · Opus 5 · 3m
```

## 変更点

- **レートを常に先頭、以降はセッションごとに 1 行** — セッション数によらず同じ形
- **1 行に収める調整** — モデルは effort まで (`think`/`fast` は落とす)、経過は API 時間を落とす、使用率は小数第 1 位へ丸める。値も幅 32 で切り詰める (`45.5% · Opus 5 · xhigh · 11h13m` がちょうど収まる幅)
- **ラベル衝突の解消** — 一覧ではラベルが唯一の識別子になるため、同じものが並ばないよう必要な分だけ細かくする: プロジェクト名 → ブランチを添える → 同じ worktree で複数開いているならセッション名。実データで `tmp · HEAD` が 2 行並ぶのを確認して追加した
- 切り詰めで末尾に区切り (` · `) が残らないようにする

一覧に絞った結果、statusLine では取れる `cost` / `edits` / `pr` / `agent` は出さなくなった。1 行に畳むと長すぎるため。必要になればセッション行の値へ足せる。

## 確認方法

```bash
python3 claude/tests/runcat_metrics_test.py
```

38 件 green。レイアウトの統一・モデルと経過の短縮・使用率の丸め・値とラベルの切り詰め・ラベル衝突の解消それぞれについて、実装を一時的に壊して赤くなることを確認した。

実 transcript 5 本でも検証済み:

```
tmp · HEAD             3.1% · Opus 4.8 · high · 1s
tmp · HEAD             3% · Opus 4.8 · high · 1s      ← この衝突を見て上記の対応を追加
divive · claude/mac…   36.9% · Opus 5 · high
divive · claude/uni…   51.7% · Opus 5 · high
setup                  62% · Opus 5 · high · 1h38m
```

ラベル最大 20 幅 / 値最大 27 幅と、いずれも上限内。

## レート制限について

`5h` / `7d` の行は控えがあるときだけ出る。現状 statusLine はターミナルの対話 TUI でしか呼ばれず、`claude -p` でも呼ばれないことを実測で確認した (symlink を差し替えて生入力を取得したところ、走っていたのは Stop hook のみ)。

ご要望の 4 つ目「週間制限 (Fable)」は、statusLine が渡す `rate_limits` が `five_hour` / `seven_day` の 2 つだけのため出せない。別途、非公式の usage エンドポイント (`GET /api/oauth/usage`) から取得できないか調査中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)