### PR TITLE
feat(claude): レート制限を使用量エンドポイントから取る

### DIFF
--- a/claude/runcat-metrics.py
+++ b/claude/runcat-metrics.py
@@ -28,8 +28,9 @@ RunCat Neo の Custom Metrics 形式
 カードはセッション数によらず同じ形をとる。行が増減して見た目が変わらない方が
 一覧として読みやすいため:
 
-    5h        23.5% · 2h41m left     レート制限 (取れたときだけ)
-    7d        41.2% · 3d4h left
+    5h        0% · 2h41m left        レート制限 (取れたときだけ)
+    7d        18% · 4d12h left
+    7d Fable  10% · 4d12h left       モデル別の枠があればそれも
     setup     21% · Opus 5 · 12m     ここから下はセッションごとに 1 行
     divive    8% · Opus 5 · 3m
 
@@ -43,11 +44,14 @@ RunCat Neo の Custom Metrics 形式
 
 メニューバーへ出す値 (metricsBarValue) は週間制限の使用率。
 
-レート制限は hook 入力にも transcript にも無いため、statusLine モードで取れた値を
-控え (RATE_LIMITS_CACHE)、hook モードではリセット時刻を過ぎるまでそれを使う。
-控えは最後に取れた時点の値で実際はそれ以上なので、下限として ≥ を付けて出す。
-モデル別の週間制限 (Opus / Sonnet / Fable) は Claude Code が statusLine へ渡すのが
-five_hour と seven_day だけのため出せない (2.1.212 時点)。
+レート制限は Claude Code の /usage と同じ使用量エンドポイント (USAGE_URL) から取る。
+statusLine が渡す rate_limits は five_hour と seven_day だけで、モデル別の週間制限
+(`7d Fable` など) はそこに来ないため。応答の limits 配列を kind と scope で読むので、
+枠が増えても拾える。トークンは keychain から読み、プロセスの中だけで使う。
+
+非公式・非文書化の API なので、壊れたときは statusLine 入力 → その控え
+(RATE_LIMITS_CACHE) の順に落ち、モデル別の行が消えるだけで他は出続ける。控えや
+古い応答から読んだ値は、その後も使用率は上がる一方なので下限として ≥ を付ける。
 
 文脈の上限は statusLine 入力にしか無い。hook モードではモデル名から引く
 (200k なのは Haiku 4.5 だけで、Claude 5 系はいずれも 1M が既定)。
@@ -68,16 +72,34 @@ version・output_style.name・vim.mode (常時見る価値が薄い)、exceeds_2
 import json
 import os
 import re
+import subprocess
 import sys
 import tempfile
 import unicodedata
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
 OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
 
-# statusLine で取れたレート制限の控え (hook モードから読む)
+# statusLine で取れたレート制限の控え (usage API が使えないときのフォールバック)
 RATE_LIMITS_CACHE = OUT.parent / "runcat-rate-limits.json"
+
+# Claude Code の /usage と同じ使用量エンドポイント。statusLine が渡す rate_limits は
+# five_hour と seven_day だけで、モデル別の週間制限はここからしか取れない。
+# 非公式・非文書化のため、壊れたら黙って statusLine の控えへ落ちる (行が消えるだけ)。
+# RUNCAT_USAGE_URL はテストから file:// のスタブを差すための差し替え口。
+USAGE_URL = os.environ.get("RUNCAT_USAGE_URL", "https://api.anthropic.com/api/oauth/usage")
+USAGE_CACHE = OUT.parent / "runcat-usage-limits.json"
+
+# hook は毎ツール呼び出しで走るので、この間隔より短ければ控えを使い回す
+USAGE_MAX_AGE_SECONDS = 60
+
+# hook を待たせないための上限。落ちても諦めて次の実行に任せる
+USAGE_TIMEOUT_SECONDS = 3
+
+# Claude Code が OAuth トークンを預けている keychain のサービス名
+KEYCHAIN_SERVICE = "Claude Code-credentials"
 
 # セッションごとの状態 (<session_id>.json)。カードはここを集約して組む
 SESSIONS_DIR = OUT.parent / "runcat-sessions"
@@ -268,6 +290,121 @@ def fmt_bar_value(window, stale=False):
     return f"{'≥' if stale else ''}{used:.0f}%"
 
 
+# --- 使用量エンドポイント --------------------------------------------------------
+
+def oauth_token():
+    """Claude Code の OAuth トークンを keychain から読む。
+
+    値はこのプロセスの中だけで使い、控えにもログにも書かない。
+    """
+    proc = subprocess.run(
+        ["/usr/bin/security", "find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+        capture_output=True, text=True, timeout=5,
+    )
+    if proc.returncode != 0:
+        return None
+    account = obj(json.loads(proc.stdout), "claudeAiOauth")
+    return account.get("accessToken") or account.get("access_token")
+
+
+def fetch_usage():
+    """使用量エンドポイントを叩いて生のレスポンスを返す。"""
+    headers = {"anthropic-beta": "oauth-2025-04-20"}
+    if not USAGE_URL.startswith("file:"):  # file: はテスト用スタブ
+        token = oauth_token()
+        if not token:
+            return None
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(USAGE_URL, headers=headers)
+    with urllib.request.urlopen(request, timeout=USAGE_TIMEOUT_SECONDS) as response:
+        return json.load(response)
+
+
+def usage_label(entry):
+    """limits の 1 件をカードのラベルへ。読めない種別は捨てる。"""
+    kind = entry.get("kind")
+    if kind == "session":
+        return "5h"
+    if kind == "weekly_all":
+        return "7d"
+    if kind == "weekly_scoped":
+        model = obj(entry, "scope", "model").get("display_name")
+        return f"7d {model}" if model else None
+    return None
+
+
+def rows_from_usage(payload, stale=False):
+    """レスポンスの limits 配列をレート制限の行へ。
+
+    kind と scope からラベルを決めるので、モデル別の枠が増えても拾える。
+    """
+    rows = []
+    limits = payload.get("limits") if isinstance(payload, dict) else None
+    for entry in limits or []:
+        if not isinstance(entry, dict):
+            continue
+        used = num(entry.get("percent"))
+        label = usage_label(entry)
+        if used is None or not label:
+            continue
+        resets_at = parse_ts(entry.get("resets_at"))
+        rows.append({
+            "label": label,
+            "used_percentage": used,
+            "resets_at": resets_at.timestamp() if resets_at else None,
+            "stale": stale,
+        })
+    return rows
+
+
+def usage_limits(now_epoch):
+    """使用量エンドポイントから取れたレート制限の行。取れなければ空。
+
+    hook は毎ツール呼び出しで走るため、USAGE_MAX_AGE_SECONDS の間は控えを使う。
+    再取得に失敗したときは古い控えで凌ぐ (使用率は上がる一方なので ≥ を付ける)。
+    """
+    try:
+        cached = json.loads(USAGE_CACHE.read_text(encoding="utf-8"))
+    except Exception:
+        cached = None
+    fetched_at = num(cached.get("fetched_at")) if isinstance(cached, dict) else None
+    if fetched_at is not None and now_epoch - fetched_at < USAGE_MAX_AGE_SECONDS:
+        return rows_from_usage(cached.get("payload"))
+
+    try:
+        payload = fetch_usage()
+    except Exception:
+        payload = None
+    if payload is not None:
+        try:
+            write_json(USAGE_CACHE, {"fetched_at": now_epoch, "payload": payload})
+        except Exception:
+            pass
+        return rows_from_usage(payload)
+    if isinstance(cached, dict) and cached.get("payload"):
+        return rows_from_usage(cached["payload"], stale=True)
+    return []
+
+
+def rows_from_windows(windows, stale):
+    """statusLine 由来の five_hour / seven_day を行へ (usage API のフォールバック)。"""
+    rows = []
+    for key, label in (("five_hour", "5h"), ("seven_day", "7d")):
+        window = windows.get(key) or {}
+        used = num(window.get("used_percentage"))
+        if used is None:
+            continue
+        rows.append({
+            "label": label,
+            "used_percentage": used,
+            "resets_at": num(window.get("resets_at")),
+            "stale": stale,
+        })
+    return rows
+
+
+# --- レート制限の控え (statusLine 由来) --------------------------------------------
+
 def save_rate_limits(windows):
     """statusLine で取れたレート制限を hook モード用に控える。"""
     kept = {}
@@ -388,15 +525,15 @@ def session_summary(state):
 
 # --- カードの組み立て -----------------------------------------------------------
 
-def build_card(states, limits, now_epoch, stale):
+def build_card(states, limit_rows, now_epoch):
     """生きているセッションからカードを組む。
 
     レート制限を頭に置き、以降はセッションごとに 1 行。セッション数によらず
     同じ形にすることで、行が増減して見た目が変わらないようにしている。
     """
     metrics = [
-        rate_limit_row("5h", limits.get("five_hour", {}), now_epoch, stale=stale),
-        rate_limit_row("7d", limits.get("seven_day", {}), now_epoch, stale=stale),
+        rate_limit_row(limit["label"], limit, now_epoch, stale=limit.get("stale", False))
+        for limit in limit_rows
     ]
     for state in states:
         ctx_pct = num(state.get("ctx_pct"))
@@ -405,7 +542,9 @@ def build_card(states, limits, now_epoch, stale):
             session_summary(state),
             ctx_pct / 100 if ctx_pct is not None else None,
         ))
-    return snapshot(metrics, fmt_bar_value(limits.get("seven_day", {}), stale=stale))
+    # メニューバーは週間 (全モデル) の使用率
+    weekly = next((limit for limit in limit_rows if limit["label"] == "7d"), {})
+    return snapshot(metrics, fmt_bar_value(weekly, stale=weekly.get("stale", False)))
 
 
 # --- statusLine モード ---------------------------------------------------------
@@ -583,11 +722,30 @@ def from_transcript(path, session_id=None):
 
 # --- エントリポイント -----------------------------------------------------------
 
-def render(state, limits, now_epoch, stale):
+def render(state, limit_rows, now_epoch):
     """自分の状態を保存し、生きている全セッションからカードを組んで書き出す。"""
     save_session(state)
     states = load_sessions(now_epoch, current_id=state.get("session_id"))
-    write_json(OUT, build_card(states, limits, now_epoch, stale))
+    write_json(OUT, build_card(states, limit_rows, now_epoch))
+
+
+def resolve_limits(payload, now_epoch):
+    """出すべきレート制限の行を決める。
+
+    使用量エンドポイントが使えればそれだけで足りる (5h / 週間 / モデル別が揃う)。
+    落ちているときは statusLine 入力、それも無ければ控えへ順に落ちる。
+    """
+    rows = usage_limits(now_epoch)
+    if rows:
+        return rows
+    windows = {
+        "five_hour": obj(payload, "rate_limits", "five_hour"),
+        "seven_day": obj(payload, "rate_limits", "seven_day"),
+    }
+    rows = rows_from_windows(windows, stale=False)
+    if rows:
+        return rows
+    return rows_from_windows(load_rate_limits(now_epoch), stale=True)
 
 
 def main():
@@ -604,21 +762,20 @@ def main():
         # hook を止めないよう、失敗しても黙って終了する
         try:
             state = from_transcript(payload["transcript_path"], payload.get("session_id"))
-            # レート制限は hook 入力に無いので statusLine モードの控えを使う
-            render(state, load_rate_limits(now_epoch), now_epoch, stale=True)
+            render(state, resolve_limits({}, now_epoch), now_epoch)
         except Exception:
             pass
         return
 
     state, model_name = from_statusline(payload)
 
-    # レート制限: hook モード (デスクトップアプリ) では取れないのでここで控えておく
+    # 使用量エンドポイントが落ちたときのために statusLine 由来の値を控えておく
     five_hour = obj(payload, "rate_limits", "five_hour")
     seven_day = obj(payload, "rate_limits", "seven_day")
     if five_hour or seven_day:
         save_rate_limits({"five_hour": five_hour, "seven_day": seven_day})
 
-    render(state, {"five_hour": five_hour, "seven_day": seven_day}, now_epoch, stale=False)
+    render(state, resolve_limits(payload, now_epoch), now_epoch)
     print(model_name)
 
 

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -22,26 +22,37 @@ SCRIPT = Path(__file__).resolve().parent.parent / "runcat-metrics.py"
 LIMIT_TITLES = ("5h", "7d")
 
 
+# 既定ではここを向けて使用量エンドポイントを叩かせない。実際の API を叩くと
+# テストが外部とネットワークに依存し、ユーザーのレート制限も消費してしまう
+NO_USAGE_URL = "file:///nonexistent/runcat-usage-stub.json"
+
+
 class ScriptTestCase(unittest.TestCase):
-    def run_script(self, stdin_text, workdir=None):
+    def run_script(self, stdin_text, workdir=None, usage_url=NO_USAGE_URL):
         """stdin を流してスクリプトを実行し、(スナップショット, stdout) を返す。
 
         workdir を渡すと出力先を共有できる (レート制限の控えやセッション状態を
-        跨ぐ実行の検証用)。
+        跨ぐ実行の検証用)。usage_url に file:// のスタブを渡すと、使用量
+        エンドポイントから取れたときの経路を検証できる。
         """
         if workdir is not None:
-            return self.run_script_in(stdin_text, Path(workdir))
+            return self.run_script_in(stdin_text, Path(workdir), usage_url)
         with tempfile.TemporaryDirectory() as tmpdir:
-            return self.run_script_in(stdin_text, Path(tmpdir))
+            return self.run_script_in(stdin_text, Path(tmpdir), usage_url)
 
-    def run_script_in(self, stdin_text, workdir):
+    def run_script_in(self, stdin_text, workdir, usage_url=NO_USAGE_URL):
         out = workdir / "usage.json"
         proc = subprocess.run(
             [sys.executable, str(SCRIPT)],
             input=stdin_text,
             capture_output=True,
             text=True,
-            env={"RUNCAT_OUT_FILE": str(out), "PATH": "/usr/bin:/bin", "HOME": str(workdir)},
+            env={
+                "RUNCAT_OUT_FILE": str(out),
+                "PATH": "/usr/bin:/bin",
+                "HOME": str(workdir),
+                "RUNCAT_USAGE_URL": usage_url,
+            },
             check=True,
         )
         return json.loads(out.read_text(encoding="utf-8")), proc.stdout.strip()
@@ -577,6 +588,160 @@ class DisplayWidthTest(ScriptTestCase):
         snapshot, _ = self.run_script(json.dumps(payload))
         self.assertEqual(self.only_session(snapshot)["title"], "setup")
         self.assertEqual(self.only_session(snapshot)["formattedValue"], "Opus 5")
+
+
+class UsageApiTest(ScriptTestCase):
+    """Claude Code の /usage と同じ使用量エンドポイントから制限を取る経路。
+
+    statusLine が渡す rate_limits には five_hour / seven_day しか無く、
+    モデル別の週間制限はここからしか取れない。
+    """
+
+    # ユーザーの実レスポンスから、行の材料になる部分だけを写したもの
+    RESPONSE = {
+        "five_hour": {"utilization": 0.0, "resets_at": "2026-07-28T09:50:00.712514+00:00"},
+        "seven_day": {"utilization": 18.0, "resets_at": "2026-08-02T00:59:59.712531+00:00"},
+        "seven_day_opus": None,
+        "limits": [
+            {"kind": "session", "group": "session", "percent": 0,
+             "resets_at": "2026-07-28T09:50:00.712514+00:00", "scope": None, "is_active": False},
+            {"kind": "weekly_all", "group": "weekly", "percent": 18,
+             "resets_at": "2026-08-02T00:59:59.712531+00:00", "scope": None, "is_active": True},
+            {"kind": "weekly_scoped", "group": "weekly", "percent": 10,
+             "resets_at": "2026-08-02T00:59:59.712746+00:00",
+             "scope": {"model": {"id": None, "display_name": "Fable"}, "surface": None},
+             "is_active": False},
+        ],
+    }
+
+    def stub(self, workdir, payload):
+        """使用量エンドポイントの代わりに読ませる file:// スタブを置く。"""
+        path = Path(workdir) / "usage-response.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path.as_uri()
+
+    def payload(self, session_id="s1", project="setup"):
+        return json.dumps({
+            "session_id": session_id,
+            "model": {"display_name": "Opus 5"},
+            "workspace": {"repo": {"name": project}},
+            "context_window": {"used_percentage": 21},
+        })
+
+    def test_all_three_limits_are_rendered(self):
+        """5 時間 / 週間 (全モデル) / 週間 (モデル別) の 3 本が出る。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = self.stub(tmpdir, self.RESPONSE)
+            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            rows = self.rows(snapshot)
+
+            self.assertEqual([m["title"] for m in snapshot["metrics"]][:3], ["5h", "7d", "7d Fable"])
+            self.assertTrue(rows["5h"]["formattedValue"].startswith("0% · "),
+                            rows["5h"]["formattedValue"])
+            self.assertTrue(rows["7d"]["formattedValue"].startswith("18% · "),
+                            rows["7d"]["formattedValue"])
+            self.assertTrue(rows["7d Fable"]["formattedValue"].startswith("10% · "),
+                            rows["7d Fable"]["formattedValue"])
+            # 控えから読んだ値ではないので ≥ は付けない
+            self.assertNotIn("≥", rows["7d"]["formattedValue"])
+            # メニューバーは週間 (全モデル)
+            self.assertEqual(snapshot["metricsBarValue"], "18%")
+
+    def test_scoped_label_comes_from_the_model_name(self):
+        """モデル別の枠が増えても scope から拾える。"""
+        response = dict(self.RESPONSE, limits=[
+            {"kind": "weekly_scoped", "percent": 42,
+             "resets_at": "2026-08-02T00:59:59+00:00",
+             "scope": {"model": {"display_name": "Opus"}}},
+        ])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = self.stub(tmpdir, response)
+            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            self.assertIn("7d Opus", self.rows(snapshot))
+
+    def test_unknown_kinds_are_skipped(self):
+        """知らない種別や percent の無い行は捨てる (増えても壊れない)。"""
+        response = dict(self.RESPONSE, limits=[
+            {"kind": "weekly_all", "percent": 18, "resets_at": "2026-08-02T00:59:59+00:00"},
+            {"kind": "brand_new_kind", "percent": 5},
+            {"kind": "session"},  # percent が無い
+            {"kind": "weekly_scoped", "percent": 7, "scope": {"model": {}}},  # 名前が無い
+            "not a dict",
+        ])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = self.stub(tmpdir, response)
+            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            self.assertEqual([m["title"] for m in snapshot["metrics"]][:1], ["7d"])
+            self.assertEqual(len(self.sessions(snapshot)), 1)
+
+    def test_response_is_cached_between_runs(self):
+        """hook は毎ツール呼び出しで走るので、短い間隔では叩き直さない。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = self.stub(tmpdir, self.RESPONSE)
+            self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+
+            # 応答の中身を差し替えても、控えが新しいうちは読み直さない
+            self.stub(tmpdir, {"limits": [
+                {"kind": "weekly_all", "percent": 99,
+                 "resets_at": "2026-08-02T00:59:59+00:00"}]})
+            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            rows = self.rows(snapshot)
+            self.assertTrue(rows["7d"]["formattedValue"].startswith("18% · "),
+                            rows["7d"]["formattedValue"])
+            self.assertIn("7d Fable", rows)
+
+    def test_stale_cache_is_marked_when_refresh_fails(self):
+        """控えが古いまま再取得に失敗したら、下限として ≥ を付ける。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = self.stub(tmpdir, self.RESPONSE)
+            self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+
+            cache = Path(tmpdir) / "runcat-usage-limits.json"
+            cached = json.loads(cache.read_text(encoding="utf-8"))
+            cached["fetched_at"] -= 3600  # USAGE_MAX_AGE_SECONDS を大きく超えさせる
+            cache.write_text(json.dumps(cached), encoding="utf-8")
+            (Path(tmpdir) / "usage-response.json").unlink()  # 再取得は失敗する
+
+            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            self.assertTrue(self.rows(snapshot)["7d"]["formattedValue"].startswith("≥18%"),
+                            self.rows(snapshot)["7d"]["formattedValue"])
+
+    def test_usage_api_wins_over_the_statusline_values(self):
+        """両方あるときは、モデル別まで取れる使用量エンドポイントを使う。"""
+        now = int(time.time())
+        payload = json.loads(self.payload())
+        payload["rate_limits"] = {
+            "five_hour": {"used_percentage": 99, "resets_at": now + 3600},
+            "seven_day": {"used_percentage": 88, "resets_at": now + 3600},
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = self.stub(tmpdir, self.RESPONSE)
+            snapshot, _ = self.run_script(json.dumps(payload), workdir=tmpdir, usage_url=url)
+            rows = self.rows(snapshot)
+            self.assertTrue(rows["7d"]["formattedValue"].startswith("18% · "),
+                            rows["7d"]["formattedValue"])
+            self.assertIn("7d Fable", rows)
+
+    def test_falls_back_to_statusline_when_the_endpoint_is_unreachable(self):
+        """エンドポイントが壊れても行が消えるだけで、他の値は出し続ける。"""
+        now = int(time.time())
+        payload = json.loads(self.payload())
+        payload["rate_limits"] = {
+            "seven_day": {"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
+        }
+        snapshot, _ = self.run_script(json.dumps(payload))  # 既定の届かない URL
+        rows = self.rows(snapshot)
+        self.assertEqual(rows["7d"]["formattedValue"], "41.2% · 3d4h left")
+        self.assertNotIn("7d Fable", rows)
+        self.assertEqual(len(self.sessions(snapshot)), 1)
+
+    def test_broken_response_does_not_break_the_card(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "usage-response.json"
+            path.write_text("{ truncated", encoding="utf-8")
+            snapshot, _ = self.run_script(
+                self.payload(), workdir=tmpdir, usage_url=path.as_uri())
+            self.assertEqual([m["title"] for m in snapshot["metrics"]], ["setup"])
 
 
 class ContextWindowTest(ScriptTestCase):


### PR DESCRIPTION
## 目的

ご要望の 4 項目のうち残っていた「5時間制限」「週間制限 (全モデル)」「週間制限 (Fable)」を出せるようにする。

statusLine が渡す `rate_limits` は `five_hour` / `seven_day` の 2 つだけで、モデル別の週間制限は含まれない。Claude Code の `/usage` が叩いているエンドポイント (`GET /api/oauth/usage`) には 3 種類とも含まれていることを確認したので、そちらから取る。

```
5h        1% · 4h49m left
7d        18% · 4d19h left
7d Fable  10% · 4d19h left
setup     63% · Opus 5
```

これで **デスクトップアプリでもレート制限が出る**。statusLine が呼ばれず hook だけが動く環境でも、エンドポイントから直接取れるため。

## 変更点

- 応答の `limits` 配列を `kind` (`session` / `weekly_all` / `weekly_scoped`) と `scope.model.display_name` で読む。モデル別の枠が増えても拾える作りにした
- hook は毎ツール呼び出しで走るので、60 秒は控えを使い回して叩き直さない
- トークンは keychain から読み、プロセスの中だけで使う

## 壊れる前提の作り

非公式・非文書化の API なので、Claude Code の更新で壊れうる。取得に失敗したら **statusLine 入力 → その控え** の順に落ち、モデル別の行が消えるだけで他の行は出続ける。古い控えから読んだ値には、その後も使用率が上がる一方であることを示す `≥` を付ける。

## セキュリティ

- トークンは控えにもログにも書かない (控えの中身を `grep` して混入がないことを確認済み)
- 控えのファイル権限は `0600`
- 出力するのは使用率とリセット時刻のみ

## 確認方法

```bash
python3 claude/tests/runcat_metrics_test.py
```

46 件 green。テストは `RUNCAT_USAGE_URL` に `file://` のスタブを差して**実 API を叩かない** (外部依存を避け、レート制限も消費しないため)。

優先順位・モデル別ラベル・キャッシュ・未知 kind のスキップ・古い控えの `≥`・フォールバックそれぞれについて、実装を一時的に壊して赤くなることを確認した。当初キャッシュのテストが「叩き直さない」性質を捕まえられていなかったので、応答の中身を差し替えて検知する形に書き直している。

実エンドポイントでも statusLine / hook 両モードで検証済み (上記の出力は実際のもの)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)