### PR TITLE
feat(claude): レート制限とセッションの間に区切りを入れる

### DIFF
--- a/claude/runcat-metrics.py
+++ b/claude/runcat-metrics.py
@@ -31,6 +31,7 @@ RunCat Neo の Custom Metrics 形式
     5h        0% · 2h41m left        レート制限 (取れたときだけ)
     7d        18% · 4d12h left
     7d Fable  10% · 4d12h left       モデル別の枠があればそれも
+    ──────    ──────                 区切り (両側が揃ったときだけ挟む)
     setup     21% · Opus 5 · 12m     ここから下はセッションごとに 1 行
     divive    8% · Opus 5 · 3m
 
@@ -126,6 +127,9 @@ MAX_VALUE_WIDTH = 32
 
 # セッション行のラベル (プロジェクト名) をこの表示幅で切る
 MAX_LABEL_WIDTH = 20
+
+# レート制限とセッションの間に挟む区切り行の中身 (ラベル側と値側の両方に使う)
+SEPARATOR_MARK = "──────"
 
 
 # --- 整形ヘルパー -------------------------------------------------------------
@@ -525,23 +529,43 @@ def session_summary(state):
 
 # --- カードの組み立て -----------------------------------------------------------
 
+def separator_row():
+    """レート制限とセッションの間の区切り。
+
+    RunCat は行を `title: formattedValue` として描くので、両方に罫線を入れて
+    ラベルでも値でもない行に見せる。
+    """
+    return {"title": SEPARATOR_MARK, "formattedValue": SEPARATOR_MARK}
+
+
 def build_card(states, limit_rows, now_epoch):
     """生きているセッションからカードを組む。
 
-    レート制限を頭に置き、以降はセッションごとに 1 行。セッション数によらず
-    同じ形にすることで、行が増減して見た目が変わらないようにしている。
+    レート制限を頭に置き、区切りを挟んで、以降はセッションごとに 1 行。
+    セッション数によらず同じ形にすることで、行が増減して見た目が変わらない。
     """
-    metrics = [
+    limits = [
         rate_limit_row(limit["label"], limit, now_epoch, stale=limit.get("stale", False))
         for limit in limit_rows
     ]
+    limits = [metric for metric in limits if metric is not None]
+
+    sessions = []
     for state in states:
         ctx_pct = num(state.get("ctx_pct"))
-        metrics.append(row(
+        metric = row(
             session_label(state, states),
             session_summary(state),
             ctx_pct / 100 if ctx_pct is not None else None,
-        ))
+        )
+        if metric is not None:
+            sessions.append(metric)
+
+    metrics = list(limits)
+    if limits and sessions:  # 片側しか無いなら区切る相手がいない
+        metrics.append(separator_row())
+    metrics += sessions
+
     # メニューバーは週間 (全モデル) の使用率
     weekly = next((limit for limit in limit_rows if limit["label"] == "7d"), {})
     return snapshot(metrics, fmt_bar_value(weekly, stale=weekly.get("stale", False)))

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -18,8 +18,8 @@ from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent.parent / "runcat-metrics.py"
 
-# カード上部に固定で並ぶレート制限の行。残りがセッション行
-LIMIT_TITLES = ("5h", "7d")
+# レート制限とセッションの間に挟まる区切り行 (runcat-metrics.py と揃える)
+SEPARATOR_MARK = "──────"
 
 
 # 既定ではここを向けて使用量エンドポイントを叩かせない。実際の API を叩くと
@@ -61,8 +61,24 @@ class ScriptTestCase(unittest.TestCase):
         return {m["title"]: m for m in snapshot["metrics"]}
 
     def sessions(self, snapshot):
-        """レート制限を除いた行 = セッション行 (カードに並ぶ順)。"""
-        return [m for m in snapshot["metrics"] if m["title"] not in LIMIT_TITLES]
+        """区切りより下の行 = セッション行 (カードに並ぶ順)。
+
+        区切りが無いのはレート制限が 1 つも取れなかったときで、その場合は
+        全部がセッション行。
+        """
+        metrics = snapshot["metrics"]
+        for i, metric in enumerate(metrics):
+            if metric["title"] == SEPARATOR_MARK:
+                return metrics[i + 1:]
+        return metrics
+
+    def limits(self, snapshot):
+        """区切りより上の行 = レート制限。"""
+        metrics = snapshot["metrics"]
+        for i, metric in enumerate(metrics):
+            if metric["title"] == SEPARATOR_MARK:
+                return metrics[:i]
+        return []
 
     def only_session(self, snapshot):
         """セッションが 1 つである前提で、その行を返す。"""
@@ -267,9 +283,9 @@ class HookModeTest(ScriptTestCase):
         self.assertEqual(session["title"], "setup")
         # Opus は 1M 文脈。142,548 / 1M = 14.2548% → 小数第 1 位へ丸める
         self.assertEqual(session["formattedValue"], "14.3% · Opus 4.8 · high · 30m")
-        # hook 入力からは取れないレート制限は出さない (控えが無ければ同様)
-        for absent in LIMIT_TITLES:
-            self.assertNotIn(absent, self.rows(snapshot))
+        # 使用量エンドポイントも控えも無いので、レート制限の行と区切りは出ない
+        self.assertEqual(self.limits(snapshot), [])
+        self.assertNotIn(SEPARATOR_MARK, self.rows(snapshot))
         self.assertNotIn("metricsBarValue", snapshot)
 
     def test_model_id_is_prettified(self):
@@ -734,6 +750,24 @@ class UsageApiTest(ScriptTestCase):
         self.assertEqual(rows["7d"]["formattedValue"], "41.2% · 3d4h left")
         self.assertNotIn("7d Fable", rows)
         self.assertEqual(len(self.sessions(snapshot)), 1)
+
+    def test_a_separator_sits_between_the_limits_and_the_sessions(self):
+        """レート制限とセッションが並ぶので、境目に区切りを挟む。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = self.stub(tmpdir, self.RESPONSE)
+            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+
+            titles = [m["title"] for m in snapshot["metrics"]]
+            self.assertEqual(titles, ["5h", "7d", "7d Fable", SEPARATOR_MARK, "setup"])
+            # ラベルでも値でもない行に見せるため、両側に同じ罫線を入れる
+            separator = self.rows(snapshot)[SEPARATOR_MARK]
+            self.assertEqual(separator["formattedValue"], SEPARATOR_MARK)
+            self.assertNotIn("normalizedValue", separator)
+
+    def test_no_separator_without_rate_limits(self):
+        """レート制限が取れないときは区切る相手がいないので挟まない。"""
+        snapshot, _ = self.run_script(self.payload())  # 既定の届かない URL
+        self.assertEqual([m["title"] for m in snapshot["metrics"]], ["setup"])
 
     def test_broken_response_does_not_break_the_card(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## 目的

一覧の上 3 行 (レート制限) と、その下のセッション行が地続きに見えていたので、境目に区切りを挟む。

```
5h        2% · 3h24m left
7d        18% · 4d18h left
7d Fable  10% · 4d18h left
──────    ──────
divive    38.5% · Opus 5 · high
.setup    7% · Opus 5 · high · 1m
setup     68.8% · Opus 5 · high · 4h12m
```

## 変更点

- RunCat は行を `title: formattedValue` として描くため、**ラベル側と値側の両方に同じ罫線**を入れて、ラベルでも値でもない行に見せる。進捗バーが出ないよう `normalizedValue` は持たせない
- 区切るのは**両側が揃ったときだけ**。レート制限が取れない環境 (使用量エンドポイントに届かず控えも無い) では、区切る相手がいないので挟まない
- テスト側の「どこまでがレート制限でどこからがセッションか」の判定も、行タイトルの決め打ちから区切り位置を見る形へ変えた。これまでは `7d Fable` のようなモデル別の行をセッション行と数えてしまう作りだった (現状のテストでは偶然影響が出ていなかった)

## 確認方法

```bash
python3 claude/tests/runcat_metrics_test.py
```

48 件 green。「区切りを入れない」「片側だけでも入れる」の両方に壊して赤くなることを確認した。実 transcript 3 本でも描画順を確認済み。

## 見え方について

スキーマ上は `title: formattedValue` と連結して描かれるため、`──────: ──────` のようにコロンが挟まる可能性がある。実際の UI が左右レイアウトならコロンは見えない。実物を見て、罫線の長さ・文字種・片側のみにするかを調整する余地がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)