### PR TITLE
feat(claude): カードをレート制限とセッションの 2 枚に分ける

### DIFF
--- a/claude/runcat-metrics.py
+++ b/claude/runcat-metrics.py
@@ -20,19 +20,19 @@ RunCat Neo の Custom Metrics 形式
    (https://code.claude.com/docs/en/hooks) ので、渡される transcript_path の
    JSONL 末尾を読んで組み立てる。stdout には何も出さない。
 
-カードは 1 枚しか無いのに Claude Code は同時に何セッションも動く。そこで各実行は
-まず自分の状態を SESSIONS_DIR/<session_id>.json へ書き、次に生きている全セッション
-(最終更新が SESSION_TTL_SECONDS 以内) を読み直してカードを組む。これで最後に走った
-セッションが他を上書きしてしまうことがなくなる。
+性質の違う 2 つを 1 枚に詰めると区切りが要って読みにくいので、カードを 2 枚に分ける。
+RunCat 側で別々のソースとして登録する (設定 → Metrics → Custom Metrics → Add
+Custom Metrics Source)。どちらも毎回まとめて書き出す:
 
-カードはセッション数によらず同じ形をとる。行が増減して見た目が変わらない方が
-一覧として読みやすいため:
+    OUT (Claude Code)              SESSIONS_OUT (Claude Sessions)
+    5h        0% · 2h41m left      setup     21% · Opus 5 · 12m
+    7d        18% · 4d12h left     divive    8% · Opus 5 · 3m
+    7d Fable  10% · 4d12h left
 
-    5h        0% · 2h41m left        レート制限 (取れたときだけ)
-    7d        18% · 4d12h left
-    7d Fable  10% · 4d12h left       モデル別の枠があればそれも
-    setup     21% · Opus 5 · 12m     ここから下はセッションごとに 1 行
-    divive    8% · Opus 5 · 3m
+Claude Code は同時に何セッションも動くので、各実行はまず自分の状態を
+SESSIONS_DIR/<session_id>.json へ書き、次に生きている全セッション (最終更新が
+SESSION_TTL_SECONDS 以内) を読み直してカードを組む。これで最後に走ったセッションが
+他を上書きしてしまうことがなくなる。
 
 セッション行のラベルはプロジェクト名。同じプロジェクトが複数あるときだけ
 ブランチ名を添えて区別する。値に入れられるもの (◯=そのモードで取れる):
@@ -42,7 +42,8 @@ RunCat Neo の Custom Metrics 形式
     モデル    Opus 5 · xhigh · think       ◯    ◯ (think/fast は無し)
     経過      12m                          ◯    ◯
 
-メニューバーへ出す値 (metricsBarValue) は週間制限の使用率。
+メニューバーへ出す値 (metricsBarValue) は、レート制限のカードが週間制限の使用率、
+セッションのカードが一番文脈を使っているセッションの使用率 (圧縮が近いものが分かる)。
 
 レート制限は Claude Code の /usage と同じ使用量エンドポイント (USAGE_URL) から取る。
 statusLine が渡す rate_limits は five_hour と seven_day だけで、モデル別の週間制限
@@ -59,14 +60,15 @@ statusLine が渡す rate_limits は five_hour と seven_day だけで、モデ�
 カードの幅は一番長い行に引きずられるので、可変長の値 (プロジェクト名・ブランチ名)
 は MAX_VALUE_WIDTH 幅で切り詰める。
 
-一覧に絞ったため、statusLine では取れるが出していないものがある: cost・
+1 セッション 1 行に絞ったため、statusLine では取れるが出していないものがある: cost・
 total_lines_added/removed・pr・agent.name・session_name (1 行に畳むと長くなる)。
 ほかに session_id・prompt_id・transcript_path・cwd (カード向きでない ID / パス)、
 version・output_style.name・vim.mode (常時見る価値が薄い)、exceeds_200k_tokens
 (使用率と重複)。必要になったらセッション行の値へ足す。
 
-環境変数 RUNCAT_OUT_FILE で出力先を上書きできる (既定: ~/.claude/runcat-usage.json)。
-レート制限の控えとセッションごとの状態は同じディレクトリに置く。
+出力先は環境変数で上書きできる: RUNCAT_OUT_FILE (既定 ~/.claude/runcat-usage.json)
+と RUNCAT_SESSIONS_OUT_FILE (既定は同じディレクトリの runcat-sessions.json)。
+レート制限の控えとセッションごとの状態も同じディレクトリに置く。
 """
 
 import json
@@ -80,7 +82,12 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+# レート制限のカード。RunCat には 2 つのソースを別々に登録する
 OUT = Path(os.environ.get("RUNCAT_OUT_FILE", str(Path.home() / ".claude" / "runcat-usage.json")))
+
+# 動いているセッションのカード (同じ名前のディレクトリはセッション状態の置き場。別物)
+SESSIONS_OUT = Path(os.environ.get(
+    "RUNCAT_SESSIONS_OUT_FILE", str(OUT.parent / "runcat-sessions.json")))
 
 # statusLine で取れたレート制限の控え (usage API が使えないときのフォールバック)
 RATE_LIMITS_CACHE = OUT.parent / "runcat-rate-limits.json"
@@ -126,6 +133,12 @@ MAX_VALUE_WIDTH = 32
 
 # セッション行のラベル (プロジェクト名) をこの表示幅で切る
 MAX_LABEL_WIDTH = 20
+
+# 2 枚のカードの見出しとアイコン (SF Symbol)
+LIMIT_CARD_TITLE = "Claude Code"
+LIMIT_CARD_SYMBOL = "staroflife"
+SESSION_CARD_TITLE = "Claude Sessions"
+SESSION_CARD_SYMBOL = "rectangle.stack"
 
 
 # --- 整形ヘルパー -------------------------------------------------------------
@@ -243,10 +256,10 @@ def context_row(used_tokens, size_tokens, used_pct=None):
     return row("Context", text, used_pct / 100)
 
 
-def snapshot(metrics, bar_value=None):
+def snapshot(title, symbol, metrics, bar_value=None):
     result = {
-        "title": "Claude Code",
-        "symbol": "staroflife",
+        "title": title,
+        "symbol": symbol,
         "metrics": [m for m in metrics if m is not None],
         "lastUpdatedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
@@ -525,16 +538,21 @@ def session_summary(state):
 
 # --- カードの組み立て -----------------------------------------------------------
 
-def build_card(states, limit_rows, now_epoch):
-    """生きているセッションからカードを組む。
-
-    レート制限を頭に置き、以降はセッションごとに 1 行。セッション数によらず
-    同じ形にすることで、行が増減して見た目が変わらないようにしている。
-    """
+def build_limit_card(limit_rows, now_epoch):
+    """レート制限のカード。5 時間・週間・モデル別が 1 行ずつ並ぶ。"""
     metrics = [
         rate_limit_row(limit["label"], limit, now_epoch, stale=limit.get("stale", False))
         for limit in limit_rows
     ]
+    # メニューバーは週間 (全モデル) の使用率
+    weekly = next((limit for limit in limit_rows if limit["label"] == "7d"), {})
+    return snapshot(LIMIT_CARD_TITLE, LIMIT_CARD_SYMBOL, metrics,
+                    fmt_bar_value(weekly, stale=weekly.get("stale", False)))
+
+
+def build_session_card(states):
+    """動いているセッションのカード。セッションごとに 1 行。"""
+    metrics = []
     for state in states:
         ctx_pct = num(state.get("ctx_pct"))
         metrics.append(row(
@@ -542,9 +560,10 @@ def build_card(states, limit_rows, now_epoch):
             session_summary(state),
             ctx_pct / 100 if ctx_pct is not None else None,
         ))
-    # メニューバーは週間 (全モデル) の使用率
-    weekly = next((limit for limit in limit_rows if limit["label"] == "7d"), {})
-    return snapshot(metrics, fmt_bar_value(weekly, stale=weekly.get("stale", False)))
+    # メニューバーは一番文脈を使っているセッションの使用率 (圧縮が近いものが分かる)
+    used = [p for p in (num(s.get("ctx_pct")) for s in states) if p is not None]
+    bar_value = f"{max(used):.0f}%" if used else None
+    return snapshot(SESSION_CARD_TITLE, SESSION_CARD_SYMBOL, metrics, bar_value)
 
 
 # --- statusLine モード ---------------------------------------------------------
@@ -723,10 +742,11 @@ def from_transcript(path, session_id=None):
 # --- エントリポイント -----------------------------------------------------------
 
 def render(state, limit_rows, now_epoch):
-    """自分の状態を保存し、生きている全セッションからカードを組んで書き出す。"""
+    """自分の状態を保存し、2 枚のカードを書き出す。"""
     save_session(state)
     states = load_sessions(now_epoch, current_id=state.get("session_id"))
-    write_json(OUT, build_card(states, limit_rows, now_epoch))
+    write_json(OUT, build_limit_card(limit_rows, now_epoch))
+    write_json(SESSIONS_OUT, build_session_card(states))
 
 
 def resolve_limits(payload, now_epoch):

--- a/claude/runcat-metrics.py
+++ b/claude/runcat-metrics.py
@@ -31,7 +31,6 @@ RunCat Neo の Custom Metrics 形式
     5h        0% · 2h41m left        レート制限 (取れたときだけ)
     7d        18% · 4d12h left
     7d Fable  10% · 4d12h left       モデル別の枠があればそれも
-    ──────    ──────                 区切り (両側が揃ったときだけ挟む)
     setup     21% · Opus 5 · 12m     ここから下はセッションごとに 1 行
     divive    8% · Opus 5 · 3m
 
@@ -127,9 +126,6 @@ MAX_VALUE_WIDTH = 32
 
 # セッション行のラベル (プロジェクト名) をこの表示幅で切る
 MAX_LABEL_WIDTH = 20
-
-# レート制限とセッションの間に挟む区切り行の中身 (ラベル側と値側の両方に使う)
-SEPARATOR_MARK = "──────"
 
 
 # --- 整形ヘルパー -------------------------------------------------------------
@@ -529,43 +525,23 @@ def session_summary(state):
 
 # --- カードの組み立て -----------------------------------------------------------
 
-def separator_row():
-    """レート制限とセッションの間の区切り。
-
-    RunCat は行を `title: formattedValue` として描くので、両方に罫線を入れて
-    ラベルでも値でもない行に見せる。
-    """
-    return {"title": SEPARATOR_MARK, "formattedValue": SEPARATOR_MARK}
-
-
 def build_card(states, limit_rows, now_epoch):
     """生きているセッションからカードを組む。
 
-    レート制限を頭に置き、区切りを挟んで、以降はセッションごとに 1 行。
-    セッション数によらず同じ形にすることで、行が増減して見た目が変わらない。
+    レート制限を頭に置き、以降はセッションごとに 1 行。セッション数によらず
+    同じ形にすることで、行が増減して見た目が変わらないようにしている。
     """
-    limits = [
+    metrics = [
         rate_limit_row(limit["label"], limit, now_epoch, stale=limit.get("stale", False))
         for limit in limit_rows
     ]
-    limits = [metric for metric in limits if metric is not None]
-
-    sessions = []
     for state in states:
         ctx_pct = num(state.get("ctx_pct"))
-        metric = row(
+        metrics.append(row(
             session_label(state, states),
             session_summary(state),
             ctx_pct / 100 if ctx_pct is not None else None,
-        )
-        if metric is not None:
-            sessions.append(metric)
-
-    metrics = list(limits)
-    if limits and sessions:  # 片側しか無いなら区切る相手がいない
-        metrics.append(separator_row())
-    metrics += sessions
-
+        ))
     # メニューバーは週間 (全モデル) の使用率
     weekly = next((limit for limit in limit_rows if limit["label"] == "7d"), {})
     return snapshot(metrics, fmt_bar_value(weekly, stale=weekly.get("stale", False)))

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -18,8 +18,10 @@ from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent.parent / "runcat-metrics.py"
 
-# レート制限とセッションの間に挟まる区切り行 (runcat-metrics.py と揃える)
-SEPARATOR_MARK = "──────"
+# カード上部に固定で並ぶレート制限の行。残りがセッション行
+def is_limit_title(title):
+    """レート制限の行かどうか。モデル別は `7d Fable` のように 7d 始まりになる。"""
+    return title in ("5h", "7d") or title.startswith("7d ")
 
 
 # 既定ではここを向けて使用量エンドポイントを叩かせない。実際の API を叩くと
@@ -60,25 +62,22 @@ class ScriptTestCase(unittest.TestCase):
     def rows(self, snapshot):
         return {m["title"]: m for m in snapshot["metrics"]}
 
-    def sessions(self, snapshot):
-        """区切りより下の行 = セッション行 (カードに並ぶ順)。
-
-        区切りが無いのはレート制限が 1 つも取れなかったときで、その場合は
-        全部がセッション行。
-        """
-        metrics = snapshot["metrics"]
-        for i, metric in enumerate(metrics):
-            if metric["title"] == SEPARATOR_MARK:
-                return metrics[i + 1:]
-        return metrics
-
     def limits(self, snapshot):
-        """区切りより上の行 = レート制限。"""
-        metrics = snapshot["metrics"]
-        for i, metric in enumerate(metrics):
-            if metric["title"] == SEPARATOR_MARK:
-                return metrics[:i]
-        return []
+        """先頭に固まっているレート制限の行。
+
+        タイトルで判定するとプロジェクト名がたまたま `7d ...` のときに拾って
+        しまうので、先頭から連続している分だけを取る。
+        """
+        out = []
+        for metric in snapshot["metrics"]:
+            if not is_limit_title(metric["title"]):
+                break
+            out.append(metric)
+        return out
+
+    def sessions(self, snapshot):
+        """レート制限より下の行 = セッション行 (カードに並ぶ順)。"""
+        return snapshot["metrics"][len(self.limits(snapshot)):]
 
     def only_session(self, snapshot):
         """セッションが 1 つである前提で、その行を返す。"""
@@ -283,9 +282,8 @@ class HookModeTest(ScriptTestCase):
         self.assertEqual(session["title"], "setup")
         # Opus は 1M 文脈。142,548 / 1M = 14.2548% → 小数第 1 位へ丸める
         self.assertEqual(session["formattedValue"], "14.3% · Opus 4.8 · high · 30m")
-        # 使用量エンドポイントも控えも無いので、レート制限の行と区切りは出ない
+        # hook 入力からは取れないレート制限は出さない (控えが無ければ同様)
         self.assertEqual(self.limits(snapshot), [])
-        self.assertNotIn(SEPARATOR_MARK, self.rows(snapshot))
         self.assertNotIn("metricsBarValue", snapshot)
 
     def test_model_id_is_prettified(self):
@@ -750,24 +748,6 @@ class UsageApiTest(ScriptTestCase):
         self.assertEqual(rows["7d"]["formattedValue"], "41.2% · 3d4h left")
         self.assertNotIn("7d Fable", rows)
         self.assertEqual(len(self.sessions(snapshot)), 1)
-
-    def test_a_separator_sits_between_the_limits_and_the_sessions(self):
-        """レート制限とセッションが並ぶので、境目に区切りを挟む。"""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            url = self.stub(tmpdir, self.RESPONSE)
-            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
-
-            titles = [m["title"] for m in snapshot["metrics"]]
-            self.assertEqual(titles, ["5h", "7d", "7d Fable", SEPARATOR_MARK, "setup"])
-            # ラベルでも値でもない行に見せるため、両側に同じ罫線を入れる
-            separator = self.rows(snapshot)[SEPARATOR_MARK]
-            self.assertEqual(separator["formattedValue"], SEPARATOR_MARK)
-            self.assertNotIn("normalizedValue", separator)
-
-    def test_no_separator_without_rate_limits(self):
-        """レート制限が取れないときは区切る相手がいないので挟まない。"""
-        snapshot, _ = self.run_script(self.payload())  # 既定の届かない URL
-        self.assertEqual([m["title"] for m in snapshot["metrics"]], ["setup"])
 
     def test_broken_response_does_not_break_the_card(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -2,7 +2,7 @@
 """claude/runcat-metrics.py のテスト。
 
 スクリプトは stdin を読んで走り切る作りなので、実際の契約
-(stdin の JSON → 出力ファイルの JSON + stdout) をサブプロセス経由で検証する。
+(stdin の JSON → 2 枚のカード JSON + stdout) をサブプロセス経由で検証する。
 
     python3 claude/tests/runcat_metrics_test.py
 """
@@ -15,13 +15,17 @@ import time
 import unicodedata
 import unittest
 from pathlib import Path
+from typing import NamedTuple
 
 SCRIPT = Path(__file__).resolve().parent.parent / "runcat-metrics.py"
 
-# カード上部に固定で並ぶレート制限の行。残りがセッション行
-def is_limit_title(title):
-    """レート制限の行かどうか。モデル別は `7d Fable` のように 7d 始まりになる。"""
-    return title in ("5h", "7d") or title.startswith("7d ")
+
+class Cards(NamedTuple):
+    """1 回の実行で書き出される 2 枚のカードと stdout。"""
+
+    limits: dict    # レート制限のカード (5h / 7d / 7d Fable)
+    sessions: dict  # 動いているセッションのカード
+    stdout: str
 
 
 # 既定ではここを向けて使用量エンドポイントを叩かせない。実際の API を叩くと
@@ -31,7 +35,7 @@ NO_USAGE_URL = "file:///nonexistent/runcat-usage-stub.json"
 
 class ScriptTestCase(unittest.TestCase):
     def run_script(self, stdin_text, workdir=None, usage_url=NO_USAGE_URL):
-        """stdin を流してスクリプトを実行し、(スナップショット, stdout) を返す。
+        """stdin を流してスクリプトを実行し、2 枚のカードと stdout を返す。
 
         workdir を渡すと出力先を共有できる (レート制限の控えやセッション状態を
         跨ぐ実行の検証用)。usage_url に file:// のスタブを渡すと、使用量
@@ -43,50 +47,42 @@ class ScriptTestCase(unittest.TestCase):
             return self.run_script_in(stdin_text, Path(tmpdir), usage_url)
 
     def run_script_in(self, stdin_text, workdir, usage_url=NO_USAGE_URL):
-        out = workdir / "usage.json"
+        limits_out = workdir / "usage.json"
+        sessions_out = workdir / "sessions.json"
         proc = subprocess.run(
             [sys.executable, str(SCRIPT)],
             input=stdin_text,
             capture_output=True,
             text=True,
             env={
-                "RUNCAT_OUT_FILE": str(out),
+                "RUNCAT_OUT_FILE": str(limits_out),
+                "RUNCAT_SESSIONS_OUT_FILE": str(sessions_out),
                 "PATH": "/usr/bin:/bin",
                 "HOME": str(workdir),
                 "RUNCAT_USAGE_URL": usage_url,
             },
             check=True,
         )
-        return json.loads(out.read_text(encoding="utf-8")), proc.stdout.strip()
+        return Cards(
+            json.loads(limits_out.read_text(encoding="utf-8")),
+            json.loads(sessions_out.read_text(encoding="utf-8")),
+            proc.stdout.strip(),
+        )
 
-    def rows(self, snapshot):
-        return {m["title"]: m for m in snapshot["metrics"]}
+    def rows(self, card):
+        return {m["title"]: m for m in card["metrics"]}
 
-    def limits(self, snapshot):
-        """先頭に固まっているレート制限の行。
+    def titles(self, card):
+        return [m["title"] for m in card["metrics"]]
 
-        タイトルで判定するとプロジェクト名がたまたま `7d ...` のときに拾って
-        しまうので、先頭から連続している分だけを取る。
-        """
-        out = []
-        for metric in snapshot["metrics"]:
-            if not is_limit_title(metric["title"]):
-                break
-            out.append(metric)
-        return out
-
-    def sessions(self, snapshot):
-        """レート制限より下の行 = セッション行 (カードに並ぶ順)。"""
-        return snapshot["metrics"][len(self.limits(snapshot)):]
-
-    def only_session(self, snapshot):
+    def only_session(self, cards):
         """セッションが 1 つである前提で、その行を返す。"""
-        rows = self.sessions(snapshot)
-        self.assertEqual(len(rows), 1, f"セッション行が 1 つではない: {rows}")
-        return rows[0]
+        metrics = cards.sessions["metrics"]
+        self.assertEqual(len(metrics), 1, f"セッション行が 1 つではない: {metrics}")
+        return metrics[0]
 
     def run_hook(self, entries, event="Stop", workdir=None):
-        """transcript JSONL を作り、hook 入力を流してスナップショットを返す。"""
+        """transcript JSONL を作り、hook 入力を流して 2 枚のカードを返す。"""
         if workdir is None:
             with tempfile.TemporaryDirectory() as tmpdir:
                 return self.run_hook(entries, event, Path(tmpdir))
@@ -95,15 +91,15 @@ class ScriptTestCase(unittest.TestCase):
         transcript.write_text(
             "".join(json.dumps(e, ensure_ascii=False) + "\n" for e in entries), encoding="utf-8"
         )
-        snapshot, stdout = self.run_script(json.dumps({
+        cards = self.run_script(json.dumps({
             "hook_event_name": event,
             "session_id": "abc123",
             "transcript_path": str(transcript),
             "cwd": "/Users/so/.setup",
         }), workdir=workdir)
         # hook の stdout は会話へ混ざり得るので何も出さない
-        self.assertEqual(stdout, "")
-        return snapshot
+        self.assertEqual(cards.stdout, "")
+        return cards
 
     def assistant_entry(self, **overrides):
         entry = {
@@ -119,6 +115,75 @@ class ScriptTestCase(unittest.TestCase):
         }
         entry.update(overrides)
         return entry
+
+
+class TwoCardsTest(ScriptTestCase):
+    """性質の違う 2 つを 1 枚に詰めず、カードを分けて書き出す。"""
+
+    def test_limits_and_sessions_go_to_separate_cards(self):
+        now = int(time.time())
+        payload = {
+            "session_id": "s1",
+            "model": {"display_name": "Opus 5"},
+            "workspace": {"repo": {"name": "setup"}},
+            "context_window": {"used_percentage": 21},
+            "rate_limits": {
+                "five_hour": {"used_percentage": 23.5, "resets_at": now + 9_660 + 30},
+                "seven_day": {"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
+            },
+        }
+        cards = self.run_script(json.dumps(payload))
+
+        # レート制限のカードにセッションは混ざらない
+        self.assertEqual(self.titles(cards.limits), ["5h", "7d"])
+        # セッションのカードにレート制限は混ざらない
+        self.assertEqual(self.titles(cards.sessions), ["setup"])
+
+    def test_each_card_has_its_own_title_and_symbol(self):
+        """RunCat の設定でどちらのソースか見分けられるようにする。"""
+        cards = self.run_script('{"session_id": "s1", "model": {"display_name": "Opus 5"}}')
+        self.assertEqual(cards.limits["title"], "Claude Code")
+        self.assertEqual(cards.sessions["title"], "Claude Sessions")
+        self.assertNotEqual(cards.limits["symbol"], cards.sessions["symbol"])
+
+    def test_both_cards_are_valid_custom_metrics_schema(self):
+        cards = self.run_script('{"model": {"display_name": "Opus 4.8"}}')
+        for card in (cards.limits, cards.sessions):
+            self.assertIsInstance(card["title"], str)
+            self.assertIsInstance(card["symbol"], str)
+            self.assertIsInstance(card["metrics"], list)
+            # lastUpdatedDate は RunCat が要求する ISO 8601 (UTC) 形式
+            self.assertRegex(card["lastUpdatedDate"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+            for metric in card["metrics"]:
+                self.assertIsInstance(metric["title"], str)
+                self.assertIsInstance(metric["formattedValue"], str)
+                if "normalizedValue" in metric:
+                    self.assertGreaterEqual(metric["normalizedValue"], 0.0)
+                    self.assertLessEqual(metric["normalizedValue"], 1.0)
+
+    def test_session_card_bar_shows_the_most_used_context(self):
+        """メニューバーからは、圧縮が近いセッションがあるか分かるようにする。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for session_id, project, pct in (("s1", "setup", 21), ("s2", "divive", 68)):
+                self.run_script(json.dumps({
+                    "session_id": session_id,
+                    "model": {"display_name": "Opus 5"},
+                    "workspace": {"repo": {"name": project}},
+                    "context_window": {"used_percentage": pct},
+                }), workdir=tmpdir)
+            cards = self.run_script(json.dumps({
+                "session_id": "s2",
+                "model": {"display_name": "Opus 5"},
+                "workspace": {"repo": {"name": "divive"}},
+                "context_window": {"used_percentage": 68},
+            }), workdir=tmpdir)
+            self.assertEqual(cards.sessions["metricsBarValue"], "68%")
+
+    def test_empty_limits_still_writes_both_cards(self):
+        """レート制限が取れなくても、セッションのカードは書き出す。"""
+        cards = self.run_script('{"session_id": "s1", "workspace": {"repo": {"name": "setup"}}}')
+        self.assertEqual(cards.limits["metrics"], [])
+        self.assertEqual(self.titles(cards.sessions), ["setup"])
 
 
 class StatusLineModeTest(ScriptTestCase):
@@ -159,39 +224,36 @@ class StatusLineModeTest(ScriptTestCase):
             "agent": {"name": "security-reviewer"},
             "pr": {"number": 1234, "review_state": "pending"},
         }
-        snapshot, stdout = self.run_script(json.dumps(payload))
-        rows = self.rows(snapshot)
+        cards = self.run_script(json.dumps(payload))
+        limits = self.rows(cards.limits)
 
-        self.assertEqual(stdout, "Opus 4.8")
-        self.assertEqual(snapshot["title"], "Claude Code")
-        # レート制限が先頭 2 行、その下がセッション行
-        self.assertEqual([m["title"] for m in snapshot["metrics"]][:2], ["5h", "7d"])
-        self.assertEqual(rows["5h"]["formattedValue"], "23.5% · 2h41m left")
-        self.assertEqual(rows["7d"]["formattedValue"], "41.2% · 3d4h left")
+        self.assertEqual(cards.stdout, "Opus 4.8")
+        self.assertEqual(limits["5h"]["formattedValue"], "23.5% · 2h41m left")
+        self.assertEqual(limits["7d"]["formattedValue"], "41.2% · 3d4h left")
         # メニューバーへ出すのは週間制限の使用率 (整数へ丸める)
-        self.assertEqual(snapshot["metricsBarValue"], "41%")
+        self.assertEqual(cards.limits["metricsBarValue"], "41%")
 
-        session = self.only_session(snapshot)
+        session = self.only_session(cards)
         self.assertEqual(session["title"], "setup")
         # 使用率 · モデルと effort · 経過。think/fast と API 時間は一覧では落とす
         self.assertEqual(session["formattedValue"], "31.4% · Opus 4.8 · xhigh · 1h15m")
         self.assertAlmostEqual(session["normalizedValue"], 0.3135)
 
     def test_empty_payload_still_renders_one_session(self):
-        snapshot, stdout = self.run_script("{}")
-        self.assertEqual(stdout, "Claude Code")
-        session = self.only_session(snapshot)
+        cards = self.run_script("{}")
+        self.assertEqual(cards.stdout, "Claude Code")
+        session = self.only_session(cards)
         # プロジェクト名もセッション名も無いときのラベル
         self.assertEqual(session["title"], "session")
         self.assertEqual(session["formattedValue"], "Claude Code")
-        self.assertNotIn("metricsBarValue", snapshot)
+        self.assertNotIn("metricsBarValue", cards.limits)
 
     def test_malformed_stdin_does_not_crash(self):
         for stdin_text in ("", "not json at all", "[1,2,3]", "null"):
             with self.subTest(stdin=stdin_text):
-                snapshot, stdout = self.run_script(stdin_text)
-                self.assertEqual(stdout, "Claude Code")
-                self.assertEqual(self.only_session(snapshot)["formattedValue"], "Claude Code")
+                cards = self.run_script(stdin_text)
+                self.assertEqual(cards.stdout, "Claude Code")
+                self.assertEqual(self.only_session(cards)["formattedValue"], "Claude Code")
 
     def test_wrong_types_are_ignored_instead_of_rendered(self):
         payload = {
@@ -202,89 +264,84 @@ class StatusLineModeTest(ScriptTestCase):
             "effort": {"level": None},
             "fast_mode": "yes",  # true でなければマーカーを出さない
         }
-        snapshot, _ = self.run_script(json.dumps(payload))
-        self.assertEqual([m["title"] for m in snapshot["metrics"]], ["session"])
-        self.assertEqual(self.only_session(snapshot)["formattedValue"], "Claude Code")
+        cards = self.run_script(json.dumps(payload))
+        self.assertEqual(self.titles(cards.sessions), ["session"])
+        self.assertEqual(self.only_session(cards)["formattedValue"], "Claude Code")
 
     def test_expired_reset_and_over_limit_percentage(self):
         payload = {"rate_limits": {"five_hour": {"used_percentage": 150, "resets_at": 1}}}
-        snapshot, _ = self.run_script(json.dumps(payload))
-        row = self.rows(snapshot)["5h"]
+        cards = self.run_script(json.dumps(payload))
+        row = self.rows(cards.limits)["5h"]
         self.assertEqual(row["formattedValue"], "150%")  # 過去のリセット時刻は添えない
         self.assertEqual(row["normalizedValue"], 1.0)  # バーは [0,1] にクランプ
         # 週間制限が無ければメニューバーの値も出さない (Context では代用しない)
-        self.assertNotIn("metricsBarValue", snapshot)
+        self.assertNotIn("metricsBarValue", cards.limits)
 
     def test_million_token_context_window(self):
         payload = {"context_window": {
             "used_percentage": 8.4, "total_input_tokens": 83_000,
             "total_output_tokens": 1_500, "context_window_size": 1_000_000,
         }}
-        snapshot, _ = self.run_script(json.dumps(payload))
-        self.assertEqual(self.only_session(snapshot)["formattedValue"], "8.4% · Claude Code")
+        cards = self.run_script(json.dumps(payload))
+        self.assertEqual(self.only_session(cards)["formattedValue"], "8.4% · Claude Code")
 
     def test_project_falls_back_to_directory_name(self):
         payload = {"workspace": {"project_dir": "/Users/so/foo/"}, "worktree": {"name": "my-feature"}}
-        snapshot, _ = self.run_script(json.dumps(payload))
+        cards = self.run_script(json.dumps(payload))
         # 同名プロジェクトが他に無いので worktree 名は添えない
-        self.assertEqual(self.only_session(snapshot)["title"], "foo")
+        self.assertEqual(self.only_session(cards)["title"], "foo")
 
     def test_zero_values_are_rendered_not_dropped(self):
         payload = {"context_window": {"used_percentage": 0}}
-        snapshot, _ = self.run_script(json.dumps(payload))
-        session = self.only_session(snapshot)
+        cards = self.run_script(json.dumps(payload))
+        session = self.only_session(cards)
         self.assertEqual(session["formattedValue"], "0% · Claude Code")
         self.assertEqual(session["normalizedValue"], 0.0)
 
-    def test_snapshot_is_valid_custom_metrics_schema(self):
-        snapshot, _ = self.run_script('{"model": {"display_name": "Opus 4.8"}}')
-        self.assertIsInstance(snapshot["title"], str)
-        self.assertIsInstance(snapshot["symbol"], str)
-        self.assertIsInstance(snapshot["metrics"], list)
-        # lastUpdatedDate は RunCat が要求する ISO 8601 (UTC) 形式
-        self.assertRegex(snapshot["lastUpdatedDate"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
-        for metric in snapshot["metrics"]:
-            self.assertIsInstance(metric["title"], str)
-            self.assertIsInstance(metric["formattedValue"], str)
-            if "normalizedValue" in metric:
-                self.assertGreaterEqual(metric["normalizedValue"], 0.0)
-                self.assertLessEqual(metric["normalizedValue"], 1.0)
-
-    def test_output_file_is_replaced_atomically(self):
+    def test_output_files_are_replaced_atomically(self):
         """一時ファイルを残さず os.replace で置き換える (RunCat が半端な内容を読まないため)。"""
         with tempfile.TemporaryDirectory() as tmpdir:
-            out = Path(tmpdir) / "usage.json"
-            out.write_text("stale", encoding="utf-8")
+            limits_out = Path(tmpdir) / "usage.json"
+            sessions_out = Path(tmpdir) / "sessions.json"
+            limits_out.write_text("stale", encoding="utf-8")
             subprocess.run(
                 [sys.executable, str(SCRIPT)],
                 input='{"model": {"display_name": "Opus 4.8"}}',
                 capture_output=True, text=True, check=True,
-                env={"RUNCAT_OUT_FILE": str(out), "PATH": "/usr/bin:/bin", "HOME": tmpdir},
+                env={
+                    "RUNCAT_OUT_FILE": str(limits_out),
+                    "RUNCAT_SESSIONS_OUT_FILE": str(sessions_out),
+                    "PATH": "/usr/bin:/bin", "HOME": tmpdir,
+                    "RUNCAT_USAGE_URL": NO_USAGE_URL,
+                },
             )
-            self.assertEqual(json.loads(out.read_text(encoding="utf-8"))["title"], "Claude Code")
-            # 出力とセッション状態だけが残る (書きかけの一時ファイルを残さない)
             self.assertEqual(
-                sorted(p.name for p in Path(tmpdir).iterdir()), ["runcat-sessions", "usage.json"])
-            self.assertEqual([p.suffix for p in (Path(tmpdir) / "runcat-sessions").iterdir()], [".json"])
+                json.loads(limits_out.read_text(encoding="utf-8"))["title"], "Claude Code")
+            # 2 枚のカードとセッション状態だけが残る (書きかけの一時ファイルを残さない)
+            self.assertEqual(
+                sorted(p.name for p in Path(tmpdir).iterdir()),
+                ["runcat-sessions", "sessions.json", "usage.json"])
+            self.assertEqual(
+                [p.suffix for p in (Path(tmpdir) / "runcat-sessions").iterdir()], [".json"])
 
 
 class HookModeTest(ScriptTestCase):
     """hook から呼ばれる経路 (デスクトップアプリではこちらだけが動く)。"""
 
     def test_transcript_renders_the_session_row(self):
-        snapshot = self.run_hook([
+        cards = self.run_hook([
             {"type": "user", "timestamp": "2026-07-23T08:48:54.157Z", "cwd": "/Users/so/.setup"},
             {"type": "custom-title", "customTitle": "RunCat 連携"},
             {"type": "pr-link", "prNumber": 23, "prRepository": "shinyaoguri/setup"},
             self.assistant_entry(),
         ])
-        session = self.only_session(snapshot)
+        session = self.only_session(cards)
         self.assertEqual(session["title"], "setup")
         # Opus は 1M 文脈。142,548 / 1M = 14.2548% → 小数第 1 位へ丸める
         self.assertEqual(session["formattedValue"], "14.3% · Opus 4.8 · high · 30m")
-        # hook 入力からは取れないレート制限は出さない (控えが無ければ同様)
-        self.assertEqual(self.limits(snapshot), [])
-        self.assertNotIn("metricsBarValue", snapshot)
+        # 使用量エンドポイントも控えも無いので、レート制限のカードは空になる
+        self.assertEqual(cards.limits["metrics"], [])
+        self.assertNotIn("metricsBarValue", cards.limits)
 
     def test_model_id_is_prettified(self):
         for model_id, expected in [
@@ -294,29 +351,28 @@ class HookModeTest(ScriptTestCase):
             ("claude-fable-5", "Fable 5"),
         ]:
             with self.subTest(model_id=model_id):
-                snapshot = self.run_hook([self.assistant_entry(
+                cards = self.run_hook([self.assistant_entry(
                     message={"model": model_id, "usage": {}}, effort=None)])
                 # エントリが 1 つだけなので経過は 0s。使用率は usage が空で出ない
-                self.assertEqual(
-                    self.only_session(snapshot)["formattedValue"], f"{expected} · 0s")
+                self.assertEqual(self.only_session(cards)["formattedValue"], f"{expected} · 0s")
 
     def test_worktree_cwd_falls_back_to_the_repository_name(self):
         """worktree の中では末尾が worktree 名になるので、元のリポジトリ名を出す。"""
-        snapshot = self.run_hook([self.assistant_entry(
+        cards = self.run_hook([self.assistant_entry(
             cwd="/Users/so/Repos/myapp/.claude/worktrees/feat-something-250692",
             gitBranch="feat/something")])
-        self.assertEqual(self.only_session(snapshot)["title"], "myapp")
+        self.assertEqual(self.only_session(cards)["title"], "myapp")
 
     def test_sidechain_entries_are_ignored(self):
         """サブエージェント (isSidechain) の usage は本セッションの文脈量ではない。"""
-        snapshot = self.run_hook([
+        cards = self.run_hook([
             {"type": "user", "timestamp": "2026-07-23T08:48:54.157Z", "cwd": "/Users/so/.setup"},
             self.assistant_entry(),
             self.assistant_entry(isSidechain=True, message={
                 "model": "claude-haiku-4-5", "usage": {"input_tokens": 10, "output_tokens": 5}}),
         ])
         self.assertEqual(
-            self.only_session(snapshot)["formattedValue"], "14.3% · Opus 4.8 · high · 30m")
+            self.only_session(cards)["formattedValue"], "14.3% · Opus 4.8 · high · 30m")
 
     def test_broken_transcript_lines_are_skipped(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -325,10 +381,10 @@ class HookModeTest(ScriptTestCase):
                 "not json\n\n" + json.dumps(self.assistant_entry()) + "\n{ truncated",
                 encoding="utf-8",
             )
-            snapshot, stdout = self.run_script(json.dumps({
+            cards = self.run_script(json.dumps({
                 "hook_event_name": "Stop", "transcript_path": str(transcript)}))
-            self.assertEqual(stdout, "")
-            self.assertIn("Opus 4.8", self.only_session(snapshot)["formattedValue"])
+            self.assertEqual(cards.stdout, "")
+            self.assertIn("Opus 4.8", self.only_session(cards)["formattedValue"])
 
     def test_huge_transcript_reads_only_the_tail(self):
         """毎ツール呼び出しで走るため、巨大な transcript でも末尾しか読まない。"""
@@ -337,25 +393,32 @@ class HookModeTest(ScriptTestCase):
         filler = [{"type": "user", "timestamp": "2026-07-23T09:10:00.000Z", "text": "x" * 2000}
                   for _ in range(400)]  # 800KB 超 > TRANSCRIPT_TAIL_BYTES (256KB)
         start = {"type": "user", "timestamp": "2026-07-23T08:48:54.157Z", "cwd": "/Users/so/.setup"}
-        snapshot = self.run_hook([start] + filler + [self.assistant_entry()])
+        cards = self.run_hook([start] + filler + [self.assistant_entry()])
         # 先頭行だけは別途読むので、セッション開始からの経過時間になる (末尾からなら 9m)
-        self.assertTrue(
-            self.only_session(snapshot)["formattedValue"].endswith("30m"),
-            self.only_session(snapshot)["formattedValue"])
+        value = self.only_session(cards)["formattedValue"]
+        self.assertTrue(value.endswith("30m"), value)
 
     def test_missing_transcript_does_not_fail_the_hook(self):
         """hook を止めないため、transcript が読めなくても異常終了しない。"""
         with tempfile.TemporaryDirectory() as tmpdir:
-            out = Path(tmpdir) / "usage.json"
+            limits_out = Path(tmpdir) / "usage.json"
+            sessions_out = Path(tmpdir) / "sessions.json"
             proc = subprocess.run(
                 [sys.executable, str(SCRIPT)],
                 input=json.dumps({"hook_event_name": "Stop", "transcript_path": "/nonexistent.jsonl"}),
                 capture_output=True, text=True,
-                env={"RUNCAT_OUT_FILE": str(out), "PATH": "/usr/bin:/bin", "HOME": tmpdir},
+                env={
+                    "RUNCAT_OUT_FILE": str(limits_out),
+                    "RUNCAT_SESSIONS_OUT_FILE": str(sessions_out),
+                    "PATH": "/usr/bin:/bin", "HOME": tmpdir,
+                    "RUNCAT_USAGE_URL": NO_USAGE_URL,
+                },
             )
             self.assertEqual(proc.returncode, 0)
             self.assertEqual(proc.stdout, "")
-            self.assertFalse(out.exists())  # 既存のカードを壊さない
+            # 既存のカードを壊さない (どちらも書かない)
+            self.assertFalse(limits_out.exists())
+            self.assertFalse(sessions_out.exists())
 
 
 class RateLimitCacheTest(ScriptTestCase):
@@ -389,14 +452,14 @@ class RateLimitCacheTest(ScriptTestCase):
             ), workdir=tmpdir)
             self.assertEqual(self.cache(tmpdir)["five_hour"]["used_percentage"], 23.5)
 
-            snapshot = self.run_hook([self.assistant_entry()], workdir=tmpdir)
-            rows = self.rows(snapshot)
+            cards = self.run_hook([self.assistant_entry()], workdir=tmpdir)
+            limits = self.rows(cards.limits)
             # 控えは最後に取れた時点の値で実際はそれ以上なので、下限として ≥ を付ける
-            self.assertEqual(rows["5h"]["formattedValue"], "≥23.5% · 2h41m left")
-            self.assertEqual(rows["7d"]["formattedValue"], "≥41.2% · 3d4h left")
-            self.assertEqual(snapshot["metricsBarValue"], "≥41%")
-            # 控えを使ってもセッション行は transcript 由来のまま
-            self.assertIn("Opus 4.8", self.only_session(snapshot)["formattedValue"])
+            self.assertEqual(limits["5h"]["formattedValue"], "≥23.5% · 2h41m left")
+            self.assertEqual(limits["7d"]["formattedValue"], "≥41.2% · 3d4h left")
+            self.assertEqual(cards.limits["metricsBarValue"], "≥41%")
+            # 控えを使ってもセッションのカードは transcript 由来のまま
+            self.assertIn("Opus 4.8", self.only_session(cards)["formattedValue"])
 
     def test_reset_windows_are_not_reused(self):
         """リセット済みのウィンドウの使用率はもう当てにならないので出さない。"""
@@ -406,9 +469,9 @@ class RateLimitCacheTest(ScriptTestCase):
                 five_hour={"used_percentage": 23.5, "resets_at": now - 60},
                 seven_day={"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
             ), workdir=tmpdir)
-            rows = self.rows(self.run_hook([self.assistant_entry()], workdir=tmpdir))
-            self.assertNotIn("5h", rows)
-            self.assertEqual(rows["7d"]["formattedValue"], "≥41.2% · 3d4h left")
+            limits = self.rows(self.run_hook([self.assistant_entry()], workdir=tmpdir).limits)
+            self.assertNotIn("5h", limits)
+            self.assertEqual(limits["7d"]["formattedValue"], "≥41.2% · 3d4h left")
 
     def test_windows_without_reset_time_are_not_cached(self):
         """リセット時刻が無いと古さを判定できないため控えない。"""
@@ -416,7 +479,8 @@ class RateLimitCacheTest(ScriptTestCase):
             self.run_script(self.statusline_payload(
                 five_hour={"used_percentage": 23.5}), workdir=tmpdir)
             self.assertFalse((Path(tmpdir) / self.CACHE_NAME).exists())
-            self.assertNotIn("5h", self.rows(self.run_hook([self.assistant_entry()], workdir=tmpdir)))
+            cards = self.run_hook([self.assistant_entry()], workdir=tmpdir)
+            self.assertNotIn("5h", self.rows(cards.limits))
 
     def test_statusline_without_rate_limits_keeps_the_cache(self):
         """API キー利用などで制限が来ないターンがあっても、控えを消さない。"""
@@ -427,18 +491,19 @@ class RateLimitCacheTest(ScriptTestCase):
             self.run_script('{"session_id": "abc123", "model": {"display_name": "Opus 4.8"}}',
                             workdir=tmpdir)
             self.assertEqual(self.cache(tmpdir)["seven_day"]["used_percentage"], 41.2)
-            self.assertIn("7d", self.rows(self.run_hook([self.assistant_entry()], workdir=tmpdir)))
+            cards = self.run_hook([self.assistant_entry()], workdir=tmpdir)
+            self.assertIn("7d", self.rows(cards.limits))
 
     def test_broken_cache_is_ignored(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             (Path(tmpdir) / self.CACHE_NAME).write_text("{ truncated", encoding="utf-8")
-            snapshot = self.run_hook([self.assistant_entry()], workdir=tmpdir)
-            self.assertIn("Opus 4.8", self.only_session(snapshot)["formattedValue"])
-            self.assertNotIn("5h", self.rows(snapshot))
+            cards = self.run_hook([self.assistant_entry()], workdir=tmpdir)
+            self.assertIn("Opus 4.8", self.only_session(cards)["formattedValue"])
+            self.assertNotIn("5h", self.rows(cards.limits))
 
 
 class MultiSessionTest(ScriptTestCase):
-    """カードは 1 枚しか無いので、同時に動くセッションを畳んで並べる。"""
+    """セッションのカードは、同時に動いているものを畳んで並べる。"""
 
     SESSIONS_DIR = "runcat-sessions"
 
@@ -468,41 +533,32 @@ class MultiSessionTest(ScriptTestCase):
     def test_every_live_session_gets_a_row(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             self.run_script(self.statusline_payload("s1", "setup", 21, 4_500_000), workdir=tmpdir)
-            snapshot, _ = self.run_script(
+            cards = self.run_script(
                 self.statusline_payload("s2", "divive", 8, 180_000), workdir=tmpdir)
-            rows = self.rows(snapshot)
+            rows = self.rows(cards.sessions)
 
             # セッションごとに 1 行へ畳む (使用率 · モデル · 経過)
             self.assertEqual(rows["setup"]["formattedValue"], "21% · Opus 5 · 1h15m")
             self.assertEqual(rows["divive"]["formattedValue"], "8% · Opus 5 · 3m")
             self.assertAlmostEqual(rows["setup"]["normalizedValue"], 0.21)
 
-    def test_a_single_session_uses_the_same_layout(self):
-        """セッションが 1 つでも形を変えない (行が増減して見た目が動かないように)。"""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            snapshot, _ = self.run_script(
-                self.statusline_payload("s1", "setup", 21, 4_500_000), workdir=tmpdir)
-            self.assertEqual([m["title"] for m in snapshot["metrics"]], ["setup"])
-            self.assertEqual(
-                self.rows(snapshot)["setup"]["formattedValue"], "21% · Opus 5 · 1h15m")
-
     def test_stale_sessions_are_dropped(self):
         """終了したセッションはカードに残さない (更新が途絶えたら畳む)。"""
         with tempfile.TemporaryDirectory() as tmpdir:
             self.run_script(self.statusline_payload("s1", "setup", 21, 4_500_000), workdir=tmpdir)
             self.age_session(tmpdir, 31 * 60)  # SESSION_TTL_SECONDS (30 分) 超え
-            snapshot, _ = self.run_script(
+            cards = self.run_script(
                 self.statusline_payload("s2", "divive", 8, 180_000), workdir=tmpdir)
-            self.assertEqual([m["title"] for m in self.sessions(snapshot)], ["divive"])
+            self.assertEqual(self.titles(cards.sessions), ["divive"])
 
     def test_same_project_rows_are_told_apart_by_branch(self):
         """同じリポジトリの worktree を 2 つ開くとラベルが衝突するのでブランチを添える。"""
         with tempfile.TemporaryDirectory() as tmpdir:
             self.run_script(
                 self.statusline_payload("s1", "setup", 21, 60_000, branch="feat/a"), workdir=tmpdir)
-            snapshot, _ = self.run_script(
+            cards = self.run_script(
                 self.statusline_payload("s2", "setup", 8, 60_000, branch="feat/b"), workdir=tmpdir)
-            rows = self.rows(snapshot)
+            rows = self.rows(cards.sessions)
             self.assertIn("setup · feat/a", rows)
             self.assertIn("setup · feat/b", rows)
 
@@ -514,9 +570,8 @@ class MultiSessionTest(ScriptTestCase):
                     self.statusline_payload(session_id, "setup", 21, 60_000, branch="main"))
                 payload["session_name"] = title
                 self.run_script(json.dumps(payload), workdir=tmpdir)
-            snapshot, _ = self.run_script(json.dumps(payload), workdir=tmpdir)
-            labels = [m["title"] for m in self.sessions(snapshot)]
-            self.assertEqual(sorted(labels), ["テスト追加", "レビューの続き"])
+            cards = self.run_script(json.dumps(payload), workdir=tmpdir)
+            self.assertEqual(sorted(self.titles(cards.sessions)), ["テスト追加", "レビューの続き"])
 
     def test_session_name_is_only_used_when_the_branch_collides(self):
         """ブランチで区別できるならセッション名は使わない (ラベルを短く保つ)。"""
@@ -526,24 +581,9 @@ class MultiSessionTest(ScriptTestCase):
                     self.statusline_payload(session_id, "setup", 21, 60_000, branch=branch))
                 payload["session_name"] = "使わないはずの名前"
                 self.run_script(json.dumps(payload), workdir=tmpdir)
-            snapshot, _ = self.run_script(json.dumps(payload), workdir=tmpdir)
-            labels = [m["title"] for m in self.sessions(snapshot)]
-            self.assertEqual(sorted(labels), ["setup · feat/a", "setup · feat/b"])
-
-    def test_rate_limits_lead_the_card(self):
-        """レート制限は主役なので常に先頭に置く。"""
-        now = int(time.time())
-        with tempfile.TemporaryDirectory() as tmpdir:
-            self.run_script(self.statusline_payload("s1", "setup", 21, 60_000), workdir=tmpdir)
-            payload = json.loads(self.statusline_payload("s2", "divive", 8, 60_000))
-            payload["rate_limits"] = {
-                "five_hour": {"used_percentage": 23.5, "resets_at": now + 9_660 + 30},
-                "seven_day": {"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
-            }
-            snapshot, _ = self.run_script(json.dumps(payload), workdir=tmpdir)
-
-            self.assertEqual([m["title"] for m in snapshot["metrics"]][:2], ["5h", "7d"])
-            self.assertEqual(snapshot["metricsBarValue"], "41%")
+            cards = self.run_script(json.dumps(payload), workdir=tmpdir)
+            self.assertEqual(
+                sorted(self.titles(cards.sessions)), ["setup · feat/a", "setup · feat/b"])
 
     def test_statusline_and_hook_share_one_row_per_session(self):
         """同じセッションの 2 つの入口が別行に割れない。"""
@@ -568,13 +608,11 @@ class DisplayWidthTest(ScriptTestCase):
         return sum(2 if unicodedata.east_asian_width(c) in "WF" else 1 for c in text)
 
     def test_long_labels_are_clipped(self):
-        payload = {
-            "workspace": {"repo": {"name": "global-claude-md-symlinks-250692"}},
-        }
-        snapshot, _ = self.run_script(json.dumps(payload))
+        payload = {"workspace": {"repo": {"name": "global-claude-md-symlinks-250692"}}}
+        cards = self.run_script(json.dumps(payload))
         # ラベルは 20 幅まで
-        self.assertEqual(self.only_session(snapshot)["title"], "global-claude-md-sy…")
-        self.assertLessEqual(self.width(self.only_session(snapshot)["title"]), 20)
+        self.assertEqual(self.only_session(cards)["title"], "global-claude-md-sy…")
+        self.assertLessEqual(self.width(self.only_session(cards)["title"]), 20)
 
     def test_long_values_are_clipped(self):
         payload = {
@@ -583,8 +621,8 @@ class DisplayWidthTest(ScriptTestCase):
             "context_window": {"used_percentage": 21},
             "effort": {"level": "xhigh"},
         }
-        snapshot, _ = self.run_script(json.dumps(payload))
-        value = self.only_session(snapshot)["formattedValue"]
+        cards = self.run_script(json.dumps(payload))
+        value = self.only_session(cards)["formattedValue"]
         self.assertLessEqual(self.width(value), 32)
         self.assertTrue(value.endswith("…"), value)
         # 先頭の使用率は必ず読める
@@ -592,16 +630,16 @@ class DisplayWidthTest(ScriptTestCase):
 
     def test_full_width_labels_count_as_two(self):
         payload = {"session_name": "アドオンのプロダクション対応レビューと後片付け"}
-        snapshot, _ = self.run_script(json.dumps(payload))
+        cards = self.run_script(json.dumps(payload))
         # プロジェクト名が無ければセッション名をラベルにする。全角は 2 幅 (20 幅 = 全角 10 文字)
-        self.assertEqual(self.only_session(snapshot)["title"], "アドオンのプロダク…")
-        self.assertLessEqual(self.width(self.only_session(snapshot)["title"]), 20)
+        self.assertEqual(self.only_session(cards)["title"], "アドオンのプロダク…")
+        self.assertLessEqual(self.width(self.only_session(cards)["title"]), 20)
 
     def test_short_values_are_left_alone(self):
         payload = {"workspace": {"repo": {"name": "setup"}}, "model": {"display_name": "Opus 5"}}
-        snapshot, _ = self.run_script(json.dumps(payload))
-        self.assertEqual(self.only_session(snapshot)["title"], "setup")
-        self.assertEqual(self.only_session(snapshot)["formattedValue"], "Opus 5")
+        cards = self.run_script(json.dumps(payload))
+        self.assertEqual(self.only_session(cards)["title"], "setup")
+        self.assertEqual(self.only_session(cards)["formattedValue"], "Opus 5")
 
 
 class UsageApiTest(ScriptTestCase):
@@ -646,10 +684,10 @@ class UsageApiTest(ScriptTestCase):
         """5 時間 / 週間 (全モデル) / 週間 (モデル別) の 3 本が出る。"""
         with tempfile.TemporaryDirectory() as tmpdir:
             url = self.stub(tmpdir, self.RESPONSE)
-            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
-            rows = self.rows(snapshot)
+            cards = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            rows = self.rows(cards.limits)
 
-            self.assertEqual([m["title"] for m in snapshot["metrics"]][:3], ["5h", "7d", "7d Fable"])
+            self.assertEqual(self.titles(cards.limits), ["5h", "7d", "7d Fable"])
             self.assertTrue(rows["5h"]["formattedValue"].startswith("0% · "),
                             rows["5h"]["formattedValue"])
             self.assertTrue(rows["7d"]["formattedValue"].startswith("18% · "),
@@ -659,7 +697,7 @@ class UsageApiTest(ScriptTestCase):
             # 控えから読んだ値ではないので ≥ は付けない
             self.assertNotIn("≥", rows["7d"]["formattedValue"])
             # メニューバーは週間 (全モデル)
-            self.assertEqual(snapshot["metricsBarValue"], "18%")
+            self.assertEqual(cards.limits["metricsBarValue"], "18%")
 
     def test_scoped_label_comes_from_the_model_name(self):
         """モデル別の枠が増えても scope から拾える。"""
@@ -670,8 +708,8 @@ class UsageApiTest(ScriptTestCase):
         ])
         with tempfile.TemporaryDirectory() as tmpdir:
             url = self.stub(tmpdir, response)
-            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
-            self.assertIn("7d Opus", self.rows(snapshot))
+            cards = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            self.assertIn("7d Opus", self.rows(cards.limits))
 
     def test_unknown_kinds_are_skipped(self):
         """知らない種別や percent の無い行は捨てる (増えても壊れない)。"""
@@ -684,9 +722,9 @@ class UsageApiTest(ScriptTestCase):
         ])
         with tempfile.TemporaryDirectory() as tmpdir:
             url = self.stub(tmpdir, response)
-            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
-            self.assertEqual([m["title"] for m in snapshot["metrics"]][:1], ["7d"])
-            self.assertEqual(len(self.sessions(snapshot)), 1)
+            cards = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            self.assertEqual(self.titles(cards.limits), ["7d"])
+            self.assertEqual(self.titles(cards.sessions), ["setup"])
 
     def test_response_is_cached_between_runs(self):
         """hook は毎ツール呼び出しで走るので、短い間隔では叩き直さない。"""
@@ -698,8 +736,8 @@ class UsageApiTest(ScriptTestCase):
             self.stub(tmpdir, {"limits": [
                 {"kind": "weekly_all", "percent": 99,
                  "resets_at": "2026-08-02T00:59:59+00:00"}]})
-            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
-            rows = self.rows(snapshot)
+            cards = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            rows = self.rows(cards.limits)
             self.assertTrue(rows["7d"]["formattedValue"].startswith("18% · "),
                             rows["7d"]["formattedValue"])
             self.assertIn("7d Fable", rows)
@@ -716,9 +754,9 @@ class UsageApiTest(ScriptTestCase):
             cache.write_text(json.dumps(cached), encoding="utf-8")
             (Path(tmpdir) / "usage-response.json").unlink()  # 再取得は失敗する
 
-            snapshot, _ = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
-            self.assertTrue(self.rows(snapshot)["7d"]["formattedValue"].startswith("≥18%"),
-                            self.rows(snapshot)["7d"]["formattedValue"])
+            cards = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            value = self.rows(cards.limits)["7d"]["formattedValue"]
+            self.assertTrue(value.startswith("≥18%"), value)
 
     def test_usage_api_wins_over_the_statusline_values(self):
         """両方あるときは、モデル別まで取れる使用量エンドポイントを使う。"""
@@ -730,8 +768,8 @@ class UsageApiTest(ScriptTestCase):
         }
         with tempfile.TemporaryDirectory() as tmpdir:
             url = self.stub(tmpdir, self.RESPONSE)
-            snapshot, _ = self.run_script(json.dumps(payload), workdir=tmpdir, usage_url=url)
-            rows = self.rows(snapshot)
+            cards = self.run_script(json.dumps(payload), workdir=tmpdir, usage_url=url)
+            rows = self.rows(cards.limits)
             self.assertTrue(rows["7d"]["formattedValue"].startswith("18% · "),
                             rows["7d"]["formattedValue"])
             self.assertIn("7d Fable", rows)
@@ -743,19 +781,20 @@ class UsageApiTest(ScriptTestCase):
         payload["rate_limits"] = {
             "seven_day": {"used_percentage": 41.2, "resets_at": now + 273_600 + 30},
         }
-        snapshot, _ = self.run_script(json.dumps(payload))  # 既定の届かない URL
-        rows = self.rows(snapshot)
+        cards = self.run_script(json.dumps(payload))  # 既定の届かない URL
+        rows = self.rows(cards.limits)
         self.assertEqual(rows["7d"]["formattedValue"], "41.2% · 3d4h left")
         self.assertNotIn("7d Fable", rows)
-        self.assertEqual(len(self.sessions(snapshot)), 1)
+        self.assertEqual(self.titles(cards.sessions), ["setup"])
 
-    def test_broken_response_does_not_break_the_card(self):
+    def test_broken_response_does_not_break_the_cards(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "usage-response.json"
             path.write_text("{ truncated", encoding="utf-8")
-            snapshot, _ = self.run_script(
+            cards = self.run_script(
                 self.payload(), workdir=tmpdir, usage_url=path.as_uri())
-            self.assertEqual([m["title"] for m in snapshot["metrics"]], ["setup"])
+            self.assertEqual(cards.limits["metrics"], [])
+            self.assertEqual(self.titles(cards.sessions), ["setup"])
 
 
 class ContextWindowTest(ScriptTestCase):
@@ -775,22 +814,22 @@ class ContextWindowTest(ScriptTestCase):
         for model, name in (("claude-opus-5", "Opus 5"), ("claude-sonnet-5", "Sonnet 5"),
                             ("claude-fable-5", "Fable 5")):
             with self.subTest(model=model):
-                snapshot = self.run_hook([self.START, self.usage_entry(model, 411_465)])
-                session = self.only_session(snapshot)
+                cards = self.run_hook([self.START, self.usage_entry(model, 411_465)])
+                session = self.only_session(cards)
                 # 415,600 / 1M = 41.56% → 小数第 1 位へ丸める
                 self.assertEqual(session["formattedValue"], f"41.6% · {name} · high · 30m")
                 self.assertAlmostEqual(session["normalizedValue"], 0.416)
 
     def test_haiku_gets_the_200k_window(self):
         """現行モデルで 200k なのは Haiku 4.5 だけ。"""
-        snapshot = self.run_hook([self.START, self.usage_entry("claude-haiku-4-5-20251001", 138_413)])
+        cards = self.run_hook([self.START, self.usage_entry("claude-haiku-4-5-20251001", 138_413)])
         self.assertEqual(
-            self.only_session(snapshot)["formattedValue"], "71.3% · Haiku 4.5 · high · 30m")
+            self.only_session(cards)["formattedValue"], "71.3% · Haiku 4.5 · high · 30m")
 
     def test_usage_above_the_known_window_does_not_exceed_100_percent(self):
         """表に無い上限のモデルでも 100% 超えの表示にはしない。"""
-        snapshot = self.run_hook([self.START, self.usage_entry("claude-haiku-4-5", 411_465)])
-        session = self.only_session(snapshot)
+        cards = self.run_hook([self.START, self.usage_entry("claude-haiku-4-5", 411_465)])
+        session = self.only_session(cards)
         self.assertTrue(session["formattedValue"].startswith("100% · "), session["formattedValue"])
         self.assertEqual(session["normalizedValue"], 1.0)
 


### PR DESCRIPTION
## 目的

レート制限と動いているセッションは性質が違うので、1 枚に詰めると区切りが要って読みにくかった ([PR #31](https://github.com/shinyaoguri/setup/pull/31) で行の区切りを試したが、RunCat が `title: formattedValue` として描くため `──────: ──────` とコロン付きになり区切りに見えなかった)。

RunCat は Custom Metrics のソースを複数登録できるので、カードごとファイルを分ける。

```
カード1: Claude Code (staroflife)      カード2: Claude Sessions (rectangle.stack)
  5h: 4% · 3h01m left                    bunkazai-info: 39.4% · Opus 4.8 · high
  7d: 18% · 4d18h left                   setup: 74.2% · Opus 5 · high · 4h35m
  7d Fable: 10% · 4d18h left             divive: 55.6% · Opus 5 · high
```

このブランチには 2 コミット入っている:

1. `revert(claude):` 行の区切りをやめる (PR #31 の revert)
2. `feat(claude):` カードを 2 枚に分ける

## 変更点

- 出力先は `RUNCAT_OUT_FILE` (既定 `~/.claude/runcat-usage.json`) と `RUNCAT_SESSIONS_OUT_FILE` (既定は同じディレクトリの `runcat-sessions.json`)。**前者は登録済みのものをそのまま使える**ので、RunCat 側の追加作業は後者だけで済む
- カードごとに見出しとアイコンを分ける (`Claude Code` / `Claude Sessions`)。RunCat の設定画面でどちらのソースか見分けられるようにするため
- メニューバーの値も分ける。レート制限は週間 (全モデル) の使用率、セッションは**一番文脈を使っているセッションの使用率** (圧縮が近いものがあるか分かる)
- どちらのカードも毎回まとめて書き出す。片方が空でも書く

revert 側では、テストの「どこまでがレート制限か」の判定だけ残した。単純に戻すと `7d Fable` のようなモデル別の行をセッション行と数える作りに戻ってしまうため。

## 確認方法

```bash
python3 claude/tests/runcat_metrics_test.py
```

48 件 green。「1 枚に戻す」「2 枚の見出しを同じにする」「セッション側のバーを殺す」「セッションのカードを書かない」の 4 通りに壊して赤くなることを確認した。実 transcript 3 本でも 2 枚に分かれることを確認済み (上記の出力は実際のもの)。

## マージ後にお願いすること

RunCat の設定で**セッション用のソースを追加**してください:

設定 → Metrics → Custom Metrics → Add Custom Metrics Source → `~/.claude/runcat-sessions.json`

既存の `runcat-usage.json` はレート制限のカードとしてそのまま使われます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)