### PR TITLE
feat(claude): RunCat のカードをセットアップ時に用意する

### DIFF
--- a/claude/runcat-metrics.py
+++ b/claude/runcat-metrics.py
@@ -69,6 +69,9 @@ version・output_style.name・vim.mode (常時見る価値が薄い)、exceeds_2
 出力先は環境変数で上書きできる: RUNCAT_OUT_FILE (既定 ~/.claude/runcat-usage.json)
 と RUNCAT_SESSIONS_OUT_FILE (既定は同じディレクトリの runcat-sessions.json)。
 レート制限の控えとセッションごとの状態も同じディレクトリに置く。
+
+`--seed` を付けて実行すると、空のカードだけ作って終わる。RunCat へソースを登録
+する時点でファイルが必要なので、セットアップ時に tasks/claude.yml から呼ぶ。
 """
 
 import json
@@ -768,7 +771,26 @@ def resolve_limits(payload, now_epoch):
     return rows_from_windows(load_rate_limits(now_epoch), stale=True)
 
 
+def seed_cards():
+    """空のカードだけ先に置く (`--seed`)。
+
+    RunCat の Custom Metrics はソースを登録する時点でファイルが存在している
+    必要がある。Claude Code を一度も動かしていない新しい環境でも登録できるよう、
+    セットアップ時にここで作っておく。中身は次の実行で埋まる。
+    既にあるカードは触らない (走らせ直しても消さない)。
+    """
+    now_epoch = datetime.now(timezone.utc).timestamp()
+    for path, card in ((OUT, build_limit_card([], now_epoch)),
+                       (SESSIONS_OUT, build_session_card([]))):
+        if not path.exists():
+            write_json(path, card)
+
+
 def main():
+    if "--seed" in sys.argv[1:]:
+        seed_cards()
+        return
+
     try:
         payload = json.load(sys.stdin)
         if not isinstance(payload, dict):

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -186,6 +186,50 @@ class TwoCardsTest(ScriptTestCase):
         self.assertEqual(self.titles(cards.sessions), ["setup"])
 
 
+class SeedTest(ScriptTestCase):
+    """`--seed` は空のカードだけ置く (RunCat へ登録するにはファイルが要るため)。"""
+
+    def seed(self, workdir):
+        limits_out = Path(workdir) / "usage.json"
+        sessions_out = Path(workdir) / "sessions.json"
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--seed"],
+            # --seed は stdin を読まない。空を渡しておけば、読んでしまう作りに
+            # 変わったとき (通常経路へ落ちたとき) にハングせず stdout の差で分かる
+            input="", capture_output=True, text=True, check=True, timeout=30,
+            env={
+                "RUNCAT_OUT_FILE": str(limits_out),
+                "RUNCAT_SESSIONS_OUT_FILE": str(sessions_out),
+                "PATH": "/usr/bin:/bin", "HOME": str(workdir),
+                "RUNCAT_USAGE_URL": NO_USAGE_URL,
+            },
+        )
+        self.assertEqual(proc.stdout, "")  # stdout は statusLine の表示に使われる
+        return limits_out, sessions_out
+
+    def test_seed_writes_both_cards_without_stdin(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            limits_out, sessions_out = self.seed(tmpdir)
+            for path, title in ((limits_out, "Claude Code"), (sessions_out, "Claude Sessions")):
+                card = json.loads(path.read_text(encoding="utf-8"))
+                self.assertEqual(card["title"], title)
+                self.assertEqual(card["metrics"], [])
+                self.assertIn("lastUpdatedDate", card)
+
+    def test_seed_does_not_clobber_existing_cards(self):
+        """セットアップを流し直しても、動いているカードを消さない。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.run_script(json.dumps({
+                "session_id": "s1",
+                "model": {"display_name": "Opus 5"},
+                "workspace": {"repo": {"name": "setup"}},
+            }), workdir=tmpdir)
+            before = (Path(tmpdir) / "sessions.json").read_text(encoding="utf-8")
+
+            self.seed(tmpdir)
+            self.assertEqual((Path(tmpdir) / "sessions.json").read_text(encoding="utf-8"), before)
+
+
 class StatusLineModeTest(ScriptTestCase):
     """ターミナルの statusLine から呼ばれる経路。"""
 

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -2,12 +2,22 @@
 # Claude Code グローバル設定 (CLAUDE.md / settings.json / statusLine スクリプト) と
 # 全プロジェクト共通スキル (claude/skills/*) のリンク
 
-# runcat-metrics.py は RunCat Neo の Custom Metrics 連携 (~/.claude/runcat-usage.json を
-# 書き出す)。上流サンプルをベースに全メトリクスを出すよう拡張し、statusLine が動かない
-# デスクトップアプリ向けに hook 経由の入口も持たせている:
+# runcat-metrics.py は RunCat Neo の Custom Metrics 連携。上流サンプルをベースに拡張し、
+# statusLine が動かないデスクトップアプリ向けに hook 経由の入口も持たせている:
 # https://github.com/runcat-dev/RunCatNeo/tree/main/docs/samples/claude-code
 # 呼び出し口は settings.json の statusLine / hooks、テストは
 # claude/tests/runcat_metrics_test.py (python3 で直接実行)
+#
+# カードは 2 枚に分けて書き出す。RunCat 側には別々のソースとして登録する:
+#
+#   設定 → Metrics → Custom Metrics → Add Custom Metrics Source
+#     ~/.claude/runcat-usage.json     レート制限 (5h / 週間 / モデル別)
+#     ~/.claude/runcat-sessions.json  動いているセッションの一覧
+#
+# この登録だけは RunCat アプリ側の設定 (security-scoped bookmark) なので playbook では
+# 面倒を見られない。代わりに、登録時にファイルが無いと選べないため、下の seed タスクで
+# 空のカードを先に置いておく。カードそのものは実行時の生成物なのでリポジトリでは
+# 管理しない (管理するのは書き出す側のスクリプトと、それを呼ぶ settings.json)。
 - name: Define Claude global config files
   ansible.builtin.set_fact:
     claude_config_files:
@@ -45,6 +55,13 @@
     state: link
     force: true
   loop: "{{ claude_config_files }}"
+
+# Claude Code を一度も動かしていない環境でも RunCat へ登録できるよう、空のカードを置く。
+# スクリプト側が「既にあるカードは触らない」ので、走らせ直しても中身は消えない。
+- name: Seed RunCat metrics cards so they can be registered in RunCat
+  ansible.builtin.command:
+    cmd: "{{ ansible_facts['env']['HOME'] }}/.claude/runcat-metrics.py --seed"
+    creates: "{{ ansible_facts['env']['HOME'] }}/.claude/runcat-sessions.json"
 
 # 全プロジェクト共通の汎用スキル。実体は claude/skills/<name>/ に置き、
 # 各スキルを ~/.claude/skills/<name> へ個別 symlink する。個別リンクなので


### PR DESCRIPTION
## 目的

別の環境で再現しやすくする。

スクリプト自体は既に `claude/runcat-metrics.py` としてリポジトリ管理・symlink 配布されていた (`~/.claude/` 配下の実行可能ファイルはこれだけで、他は Claude Code の生成物)。だが**それだけでは新しいマシンで RunCat への登録ができなかった**。

RunCat の Custom Metrics はソースを登録する時点でファイルが存在している必要がある。カードは実行時の生成物なので、Claude Code を一度も動かしていない環境には無く、設定画面でファイルを選べない。

## 変更点

- `runcat-metrics.py --seed` を追加。空のカードを 2 枚置くだけで終わる。**既にあるカードは触らない**ので、セットアップを流し直しても中身を消さない
- [tasks/claude.yml](tasks/claude.yml) から symlink 作成の直後に呼ぶ (`creates` で冪等)
- あわせて [tasks/claude.yml](tasks/claude.yml) のコメントに、RunCat へ登録する 2 つのパスと手順を書き足した:

```
設定 → Metrics → Custom Metrics → Add Custom Metrics Source
  ~/.claude/runcat-usage.json     レート制限 (5h / 週間 / モデル別)
  ~/.claude/runcat-sessions.json  動いているセッションの一覧
```

この登録だけは RunCat アプリ側の設定 (security-scoped bookmark) なので playbook では面倒を見られない。だからこそ手順の置き場が要る。

## 管理する / しないの切り分け

カードそのものは引き続きリポジトリで管理しない (生成物)。管理するのは**書き出す側**のスクリプトと、それを呼ぶ `settings.json` という切り分けは変えていない。

```
CLAUDE.md                symlink → リポジトリ管理
settings.json            symlink → リポジトリ管理
runcat-metrics.py        symlink → リポジトリ管理
runcat-usage.json        生成物 (playbook が空で置く → 実行時に埋まる)
runcat-sessions.json     生成物 (同上)
runcat-usage-limits.json 生成物 (usage API の控え)
```

## 確認方法

```bash
python3 claude/tests/runcat_metrics_test.py
```

50 件 green。「`--seed` を無視する」「既存カードを上書きする」の両方に壊して赤くなることを確認した。

- カードの無い状態で `--seed` を実行し、`Claude Code` / `Claude Sessions` の空カード 2 枚 (権限 0600) ができることを確認
- 既存環境では `creates` によりスキップされることを `ansible-playbook --tags claude --check` で確認

なお `--seed` のテストは stdin を空で渡している。これがないと、`--seed` の判定を壊したときに通常経路へ落ちて stdin 待ちでハングし、テストが失敗ではなくタイムアウトになる (実際に一度踏んだ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)