### PR TITLE
fix(claude): コミット署名を事前確認して 1Password 待ちで詰まらせない

### DIFF
--- a/claude/git-signing-preflight.sh
+++ b/claude/git-signing-preflight.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Claude Code の PreToolUse フック: コミット署名 (1Password の op-ssh-sign) の事前確認。
+#
+# 1Password の SSH agent は署名のたびに承認を求めることがあり、要求元がフォアグラウンドの
+# GUI アプリでないときはダイアログを出さずメニューバーで知らせるだけになる。誰も気付かない
+# まま 60 秒でタイムアウトして署名が落ちる (1Password のログ上は ssh authorization prompt
+# timed out)。そのうえ失敗するたび再試行すると承認待ちが積み上がる。
+#
+# そこで git commit などを実行する前に、短いタイムアウトで捨て置きの署名を 1 回試す。
+#   - 通れば以降の本番の署名も同じセッション承認で通る (ウォームアップ)
+#   - 通らなければ 60 秒待たずにその場で止め、何をすれば直るかを伝える (即中断)
+# あわせて、署名なしコミットへの逃げ道もここで塞ぐ。
+#
+# 契約: stdin に PreToolUse の JSON。素通しは無出力 + 終了コード 0、拒否は
+# permissionDecision=deny の JSON。呼び出し口は settings.json の hooks.PreToolUse、
+# テストは claude/tests/git_signing_preflight_test.py (python3 で直接実行)。
+#
+# テスト用の差し替え口:
+#   CLAUDE_SIGNING_PREFLIGHT_SIGNER   op-ssh-sign のパス (既定は gpg.ssh.program)
+#   CLAUDE_SIGNING_PREFLIGHT_TIMEOUT  ウォームアップ署名の制限時間 (秒)
+
+set -uo pipefail
+
+readonly TIMEOUT="${CLAUDE_SIGNING_PREFLIGHT_TIMEOUT:-10}"
+
+# deny の理由文はそのままエージェントへの指示になるので「次に何をするか」まで書く。
+# ここで自動リトライを禁じておかないと、承認待ちが積み上がって状況が悪化する。
+readonly NEXT_STEP='そのうえで同じコマンドをもう一度だけ実行する。それでも通らなければ手を止めてユーザーに報告し、指示を仰ぐ。同じコマンドを繰り返し試さない (承認待ちが積み上がって状況が悪化する)。署名のバイパスは最後まで選択肢にしない。'
+
+# 1Password が終了していると agent も一緒に止まる。ソケットのファイルだけは残るので
+# 「設定は正しいのに繋がらない」に見える。
+readonly REMEDY_NOT_RUNNING="1Password アプリが起動していない (SSH agent はアプリと一緒に止まる)。
+対処: 1Password を起動する。ウィンドウを閉じるたびに終了してしまう場合は、1Password の設定で「メニューバーに 1Password を表示し続ける」を有効にすると再発しない。
+${NEXT_STEP}"
+
+readonly REMEDY_NO_RESPONSE="1Password が承認を待っている (プロンプトが背面にいる) か、ロックされている可能性が高い。
+対処は順に:
+(1) メニューバーの 1Password アイコンを確認する。承認プロンプトが背面にいることがある (60 秒で失効する)
+(2) 1Password を開いてロックを解除する。60 分で自動ロックされ、画面ロック中は Touch ID すら出せない
+${NEXT_STEP}"
+
+readonly REMEDY_GENERIC="対処: 1Password が起動していること、ロックが解除されていること、承認プロンプトが背面で待っていないことを順に確かめる。
+${NEXT_STEP}"
+
+deny() {
+  jq -n --arg reason "$1" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+  exit 0
+}
+
+payload=$(cat)
+command=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+[ -n "$command" ] || exit 0
+
+# 署名なしコミットは禁止 (全コミット Verified 運用)
+if printf '%s' "$command" | grep -qiE -- '--no-gpg-sign|gpgsign[[:space:]=]+(false|0)'; then
+  deny "署名なしコミットは禁止 (全コミット Verified 運用)。--no-gpg-sign / commit.gpgsign=false は使わない。
+${REMEDY_GENERIC}"
+fi
+
+# 署名が走るサブコマンドだけを対象にする。git のグローバルオプションには値を別の語で取る
+# ものがある (git -C <path> commit) ので、正規表現ではなく語を順に見てサブコマンドを決める。
+needs_signing() {
+  local raw="$1" segment
+  set -f # サブコマンドの判定にファイル名展開は要らない
+  while IFS= read -r segment; do
+    set -- $segment
+    # コマンド名の手前に付くもの (VAR=1 git ... / env git ...) を読み飛ばす
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+      *=* | env | sudo | command | nohup) shift ;;
+      *) break ;;
+      esac
+    done
+    case "${1:-}" in
+    git | */git) shift ;;
+    *) continue ;;
+    esac
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+      -C | -c | --git-dir | --work-tree | --exec-path | --namespace)
+        shift
+        [ "$#" -gt 0 ] && shift
+        ;;
+      -*) shift ;;
+      commit | merge | revert | cherry-pick | rebase | tag)
+        set +f
+        return 0
+        ;;
+      *) break ;;
+      esac
+    done
+  done <<EOF
+$(printf '%s' "$raw" | tr ';&|\n' '\n\n\n\n')
+EOF
+  set +f
+  return 1
+}
+
+needs_signing "$command" || exit 0
+
+signer="${CLAUDE_SIGNING_PREFLIGHT_SIGNER:-$(git config --get gpg.ssh.program 2>/dev/null)}"
+# 1Password 以外で署名している環境ではこのフックの出番はない
+case "$signer" in
+*op-ssh-sign) ;;
+*) exit 0 ;;
+esac
+[ -x "$signer" ] || deny "コミット署名の署名プログラムが見つからない: ${signer}
+gpg.ssh.program が指す op-ssh-sign が実行できない。1Password がインストールされているか確認する。"
+
+key=$(git config --get user.signingkey 2>/dev/null)
+[ -n "$key" ] && [ -r "$key" ] || deny "コミット署名の公開鍵が読めない: ${key:-(user.signingkey が未設定)}
+ansible-playbook playbook_sillicon_mac.yml --tags git で設定し直せる (setup リポジトリ)。"
+
+# 署名の置き場は空のディレクトリにする。op-ssh-sign は署名先の名前を渡した名前から
+# 組み立てる (拡張子を .sig に差し替える) ので、決め打ちにすると取りこぼす。
+tmpdir=$(mktemp -d -t signing-preflight) || exit 0
+trap 'rm -rf "$tmpdir"' EXIT
+tmp="$tmpdir/payload"
+out="$tmpdir/output"
+printf 'preflight' >"$tmp"
+
+# 捨て置きの署名を 1 回試す。承認プロンプトが出たまま返ってこない場合に備えて自前で打ち切る
+# (macOS の素の環境に timeout(1) はない)。
+"$signer" -Y sign -n git -f "$key" "$tmp" >"$out" 2>&1 &
+signer_pid=$!
+timed_out=""
+waited=0
+while kill -0 "$signer_pid" 2>/dev/null; do
+  if [ "$waited" -ge "$((TIMEOUT * 10))" ]; then
+    kill -TERM "$signer_pid" 2>/dev/null
+    timed_out=1
+    break
+  fi
+  sleep 0.1
+  waited=$((waited + 1))
+done
+wait "$signer_pid"
+signer_status=$?
+
+if [ -n "$timed_out" ]; then
+  deny "コミット署名の事前確認が ${TIMEOUT} 秒で応答しなかった。
+${REMEDY_NO_RESPONSE}"
+fi
+
+signature=$(find "$tmpdir" -name '*.sig' -size +0c 2>/dev/null | head -1)
+if [ "$signer_status" -ne 0 ] || [ -z "$signature" ]; then
+  signer_output=$(head -c 500 "$out" 2>/dev/null)
+  # agent へ繋がらないのは 1Password が動いていないとき。原因が確定するので個別に案内する
+  case "$signer_output" in
+  *"Could not connect to socket"* | *"Is the agent running"*) remedy="$REMEDY_NOT_RUNNING" ;;
+  *) remedy="$REMEDY_GENERIC" ;;
+  esac
+  deny "コミット署名の事前確認に失敗した (終了コード ${signer_status})。
+op-ssh-sign の出力: ${signer_output}
+${remedy}"
+fi
+
+# ここまで来れば署名は通る。本番のコミットは同じセッション承認に乗る
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -36,9 +36,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // \"\"' | grep -qiE -- '--no-gpg-sign|gpgsign[[:space:]=]+(false|0)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"署名なしコミットは禁止(全コミット Verified 運用)。--no-gpg-sign / commit.gpgsign=false は使わない。署名が失敗するときは順に対処する: (1) 1Password アプリを起動しロックを解除する (2) TMPDIR=/private/tmp git commit ... で再実行する。サンドボックス既定の TMPDIR からは op-ssh-sign が 1Password に到達できず Could not connect to socket / failed to fill whole buffer になる (3) それでも失敗するならユーザーに報告して指示を仰ぐ。署名のバイパスは最後まで選択肢にしない。\"}}' || true",
-            "timeout": 10,
-            "statusMessage": "コミット署名ポリシーを確認中"
+            "command": "~/.claude/git-signing-preflight.sh",
+            "timeout": 20,
+            "statusMessage": "コミット署名を事前確認中"
           }
         ]
       }

--- a/claude/tests/git_signing_preflight_test.py
+++ b/claude/tests/git_signing_preflight_test.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""claude/git-signing-preflight.sh のテスト。
+
+フックは stdin の JSON を読んで走り切る作りなので、実際の契約
+(stdin の JSON → stdout の deny JSON / 無出力) をサブプロセス経由で検証する。
+op-ssh-sign は本物を呼ぶと 1Password の承認プロンプトが出てしまうため、
+CLAUDE_SIGNING_PREFLIGHT_SIGNER で偽物に差し替える。
+
+    python3 claude/tests/git_signing_preflight_test.py
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "git-signing-preflight.sh"
+
+# 偽の op-ssh-sign。git は `-Y sign -n git -f <鍵> <署名対象>` の順で呼ぶので、
+# 署名対象は常に最後の引数になる。
+SIGNER_OK = """#!/bin/sh
+eval payload=\\${$#}
+printf -- '-----BEGIN SSH SIGNATURE-----\\n' > "$payload.sig"
+"""
+
+SIGNER_FAILS = """#!/bin/sh
+echo "1Password: No such file or directory (os error 2)" >&2
+exit 1
+"""
+
+# 1Password アプリが終了しているとこうなる (ソケットのファイルだけは残る)
+SIGNER_NOT_RUNNING = """#!/bin/sh
+echo "1Password: Could not connect to socket. Is the agent running?" >&2
+exit 1
+"""
+
+# 承認プロンプトが背面で待ち続けている状態 (1Password 側は 60 秒で失効させる) の再現
+SIGNER_HANGS = """#!/bin/sh
+sleep 60
+"""
+
+# 署名は 0 で返るのに署名ファイルが無い、という壊れ方も落としたい
+SIGNER_SILENTLY_EMPTY = """#!/bin/sh
+exit 0
+"""
+
+# 本物の op-ssh-sign は署名先の名前を渡した名前から組み立てる (p.txt なら p.sig)。
+# こちらで名前を決め打ちすると取りこぼすので、名前を変えてくる署名でも通ることを守る。
+SIGNER_RENAMES_SIGNATURE = """#!/bin/sh
+eval payload=\\${$#}
+printf -- '-----BEGIN SSH SIGNATURE-----\\n' > "$(dirname "$payload")/renamed.sig"
+"""
+
+
+class HookTestCase(unittest.TestCase):
+    def setUp(self):
+        self.workdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.workdir.name)
+        self.addCleanup(self.workdir.cleanup)
+
+        # user.signingkey はリポジトリ設定から読むので、テスト用のリポジトリを用意する
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=self.repo, check=True)
+        self.key = self.root / "signing_key.pub"
+        self.key.write_text("ssh-ed25519 AAAA... test\n")
+        self.set_signing_key(str(self.key))
+
+    def set_signing_key(self, value):
+        subprocess.run(
+            ["git", "config", "--local", "user.signingkey", value],
+            cwd=self.repo,
+            check=True,
+        )
+
+    def make_signer(self, body, name="op-ssh-sign"):
+        """偽の op-ssh-sign を置いてそのパスを返す。
+
+        名前が op-ssh-sign で終わるかどうかでフックの対象判定が変わるので、
+        名前も差し替えられるようにしておく。
+        """
+        path = self.root / name
+        path.write_text(body)
+        path.chmod(0o755)
+        return str(path)
+
+    def run_hook(self, command, signer=None, timeout=None):
+        env = dict(os.environ)
+        env["CLAUDE_SIGNING_PREFLIGHT_SIGNER"] = (
+            signer if signer is not None else self.make_signer(SIGNER_OK)
+        )
+        env["CLAUDE_SIGNING_PREFLIGHT_TIMEOUT"] = str(timeout if timeout else 5)
+        return subprocess.run(
+            [str(SCRIPT)],
+            input=json.dumps({"tool_name": "Bash", "tool_input": {"command": command}}),
+            capture_output=True,
+            text=True,
+            cwd=self.repo,
+            env=env,
+            timeout=90,
+        )
+
+    def assert_allowed(self, result):
+        """素通し (無出力 + 終了コード 0) を確かめる。"""
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "", "素通しのはずが出力があった")
+
+    def assert_denied(self, result):
+        """deny の JSON を返していることを確かめ、理由の文字列を返す。"""
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        output = payload["hookSpecificOutput"]
+        self.assertEqual(output["hookEventName"], "PreToolUse")
+        self.assertEqual(output["permissionDecision"], "deny")
+        return output["permissionDecisionReason"]
+
+
+class BypassTest(HookTestCase):
+    """署名なしコミットへの逃げ道は塞ぐ。"""
+
+    def test_no_gpg_sign_is_denied(self):
+        reason = self.assert_denied(self.run_hook('git commit --no-gpg-sign -m "x"'))
+        self.assertIn("署名なしコミットは禁止", reason)
+
+    def test_gpgsign_false_is_denied(self):
+        reason = self.assert_denied(
+            self.run_hook('git -c commit.gpgsign=false commit -m "x"')
+        )
+        self.assertIn("署名なしコミットは禁止", reason)
+
+    def test_bypass_is_denied_even_without_signing_setup(self):
+        """署名の設定を見に行く前に落とす (設定不備を口実に素通ししない)。"""
+        self.set_signing_key(str(self.root / "missing.pub"))
+        self.assert_denied(
+            self.run_hook('git commit --no-gpg-sign -m "x"', signer="/nonexistent")
+        )
+
+
+class ScopeTest(HookTestCase):
+    """署名が走らないものにまで事前確認を持ち込まない。"""
+
+    def test_unrelated_command_passes(self):
+        self.assert_allowed(self.run_hook("ls -la"))
+
+    def test_read_only_git_command_passes(self):
+        self.assert_allowed(self.run_hook("git status --short"))
+
+    def test_signer_other_than_1password_passes(self):
+        """1Password 以外で署名している環境ではこのフックの出番はない。"""
+        signer = self.make_signer(SIGNER_FAILS, name="gpg")
+        self.assert_allowed(self.run_hook('git commit -m "x"', signer=signer))
+
+    def test_commit_after_another_command_is_checked(self):
+        """&& でつないだ先の commit も拾う。"""
+        signer = self.make_signer(SIGNER_FAILS)
+        self.assert_denied(
+            self.run_hook('git add -A && git commit -m "x"', signer=signer)
+        )
+
+    def test_git_with_global_option_is_checked(self):
+        signer = self.make_signer(SIGNER_FAILS)
+        self.assert_denied(
+            self.run_hook('git -C /tmp/repo commit -m "x"', signer=signer)
+        )
+
+    def test_signed_tag_is_checked(self):
+        signer = self.make_signer(SIGNER_FAILS)
+        self.assert_denied(self.run_hook('git tag -s v1.0 -m "x"', signer=signer))
+
+    def test_env_prefixed_commit_is_checked(self):
+        signer = self.make_signer(SIGNER_FAILS)
+        self.assert_denied(
+            self.run_hook('TMPDIR=/private/tmp git commit -m "x"', signer=signer)
+        )
+
+    def test_commit_inside_a_string_is_not_checked(self):
+        """コマンドとして走らない commit を拾って読み取り操作まで止めない。"""
+        signer = self.make_signer(SIGNER_FAILS)
+        self.assert_allowed(self.run_hook('echo "git commit -m x"', signer=signer))
+
+
+class PreflightTest(HookTestCase):
+    """署名できるかを実際に試してから通す。"""
+
+    def test_commit_passes_when_signing_works(self):
+        self.assert_allowed(self.run_hook('git commit -m "x"'))
+
+    def test_commit_is_denied_when_signing_fails(self):
+        signer = self.make_signer(SIGNER_FAILS)
+        reason = self.assert_denied(self.run_hook('git commit -m "x"', signer=signer))
+        self.assertIn("事前確認に失敗", reason)
+        # 何が起きたのかを判断できるよう、署名プログラムの出力をそのまま渡す
+        self.assertIn("os error 2", reason)
+
+    def test_signature_is_found_even_if_the_signer_names_it(self):
+        """署名ファイルの名前を決め打ちにしない (op-ssh-sign は名前を組み立て直す)。"""
+        signer = self.make_signer(SIGNER_RENAMES_SIGNATURE)
+        self.assert_allowed(self.run_hook('git commit -m "x"', signer=signer))
+
+    def test_commit_is_denied_when_signature_is_missing(self):
+        signer = self.make_signer(SIGNER_SILENTLY_EMPTY)
+        reason = self.assert_denied(self.run_hook('git commit -m "x"', signer=signer))
+        self.assertIn("事前確認に失敗", reason)
+
+    def test_commit_is_denied_without_waiting_for_the_prompt_to_expire(self):
+        """承認プロンプトが背面で待っている場合、60 秒の失効を待たずに打ち切る。"""
+        signer = self.make_signer(SIGNER_HANGS)
+        result = self.run_hook('git commit -m "x"', signer=signer, timeout=1)
+        reason = self.assert_denied(result)
+        self.assertIn("応答しなかった", reason)
+        self.assertIn("1Password", reason)
+
+    def test_missing_signing_key_is_denied(self):
+        self.set_signing_key(str(self.root / "missing.pub"))
+        reason = self.assert_denied(self.run_hook('git commit -m "x"'))
+        self.assertIn("公開鍵が読めない", reason)
+
+    def test_missing_signer_binary_is_denied(self):
+        reason = self.assert_denied(
+            self.run_hook(
+                'git commit -m "x"', signer=str(self.root / "nowhere/op-ssh-sign")
+            )
+        )
+        self.assertIn("署名プログラムが見つからない", reason)
+
+
+class RemedyTest(HookTestCase):
+    """止めるだけでなく、症状に合った直し方を伝える。"""
+
+    def test_agent_not_running_is_told_apart(self):
+        """1Password が終了しているときは、そう言い当てて常駐の設定まで案内する。"""
+        signer = self.make_signer(SIGNER_NOT_RUNNING)
+        reason = self.assert_denied(self.run_hook('git commit -m "x"', signer=signer))
+        self.assertIn("1Password アプリが起動していない", reason)
+        self.assertIn("メニューバー", reason)
+        # ロックや承認の話に迷い込ませない
+        self.assertNotIn("ロックを解除", reason)
+
+    def test_no_response_points_at_the_prompt_and_the_lock(self):
+        signer = self.make_signer(SIGNER_HANGS)
+        reason = self.assert_denied(
+            self.run_hook('git commit -m "x"', signer=signer, timeout=1)
+        )
+        self.assertIn("承認プロンプト", reason)
+        self.assertIn("ロックを解除", reason)
+
+    def test_every_denial_forbids_retrying(self):
+        for name, body in (
+            ("失敗", SIGNER_FAILS),
+            ("未起動", SIGNER_NOT_RUNNING),
+        ):
+            with self.subTest(name):
+                signer = self.make_signer(body)
+                reason = self.assert_denied(
+                    self.run_hook('git commit -m "x"', signer=signer)
+                )
+                self.assertIn("繰り返し試さない", reason)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -18,12 +18,17 @@
 # 面倒を見られない。代わりに、登録時にファイルが無いと選べないため、下の seed タスクで
 # 空のカードを先に置いておく。カードそのものは実行時の生成物なのでリポジトリでは
 # 管理しない (管理するのは書き出す側のスクリプトと、それを呼ぶ settings.json)。
+#
+# git-signing-preflight.sh は 1Password の承認待ちでコミット署名が落ちるのを防ぐ
+# PreToolUse フック。呼び出し口は settings.json の hooks、テストは
+# claude/tests/git_signing_preflight_test.py (python3 で直接実行)
 - name: Define Claude global config files
   ansible.builtin.set_fact:
     claude_config_files:
       - CLAUDE.md
       - settings.json
       - runcat-metrics.py
+      - git-signing-preflight.sh
 
 - name: Create ~/.claude directory
   ansible.builtin.file:

--- a/tasks/git.yml
+++ b/tasks/git.yml
@@ -6,6 +6,9 @@
 #   2. Settings → Developer → "Use the SSH agent" を有効化
 #   3. Settings → Developer → "Integrate with 1Password CLI" を有効化
 #   4. 署名用 SSH 鍵アイテムを vault に保存
+#   5. Settings → General → "Keep 1Password in the menu bar" を有効化
+#      SSH agent はアプリと一緒に止まる。常駐させておかないと、ウィンドウを閉じた時点で
+#      コミット署名が Could not connect to socket で落ちるようになる
 # 完了後:  ansible-playbook playbook_sillicon_mac.yml --tags git
 
 - name: Set Git global username
@@ -39,6 +42,7 @@
       - "  2. Settings → Developer → Use the SSH agent を有効化"
       - "  3. Settings → Developer → Integrate with 1Password CLI を有効化"
       - "  4. 署名用 SSH 鍵アイテムを vault に保存"
+      - "  5. Settings → General → Keep 1Password in the menu bar を有効化"
       - "完了後:  ansible-playbook playbook_sillicon_mac.yml --tags git"
   when: ssh_pubkey.rc != 0 or ssh_pubkey.stdout == ""
 


### PR DESCRIPTION
## 目的

1Password で SSH 署名するコミットが、作業場所を変えるたびに落ちる件の手当て。

1Password のログ (`~/Library/Group Containers/2BUA8C4S2C.com.1password/.../logs/`) を調べたところ、原因は 3 つ重なっていた。

```
385 [ssh/op-ssh-agent] ssh authorization prompt timed out
 39 [ssh/op-ssh-agent] Session was not authorized
 19 [ssh/op-ssh-agent] Notifying user through tray icon that they have a background prompt waiting
 40 [op-sys-info]      failed to find NSApplication related to pid ...
  4 [ssh/op-agent-controller] failed to unlock app
```

1. **承認プロンプトが前面に出ない。** 要求元がフォアグラウンドの GUI アプリでないと、1Password はダイアログを出さずメニューバーで知らせるだけになる。気付かないまま 60 秒で失効する。7/17 のログでは 4 件の要求が同時に出て、ちょうど 60 秒後に一斉タイムアウトしていた。7/22 は 1 日で 278 件。
2. **承認が使い回されない。** `sshAgent.sshSessionDuration = 12h` の「セッション」は呼び出し元のプロセスツリー単位。`failed to find NSApplication` が出るとおり、毎回新しい `git` プロセス自体がセッション主体になり、ワークツリーやターミナルが変わるたびに承認がやり直しになる。
3. **1Password が終了すると agent ごと止まる。** 設定が `Keep 1Password in the menu bar = false` のため、ウィンドウを閉じた時点でアプリが終了する。ソケットのファイルだけ残るので、設定は正しいのに `Could not connect to socket. Is the agent running?` になる。調査中に実際にこの状態になり、コミットが落ちるところまで再現した。

## 変更点

- **`claude/git-signing-preflight.sh`** (新規): `git commit` などの前に、捨て置きの署名を 1 回試す PreToolUse フック。
  - 通れば本番の署名も同じセッション承認に乗る (ウォームアップ)
  - 通らなければ 60 秒待たずその場で止め、症状ごとに直し方を返す (未起動 / 応答なし / その他)
  - 理由文で再試行を禁じ、失敗のたびに承認待ちが積み上がるのを防ぐ
  - 対象は署名が走るサブコマンドだけ。`git -C <path> commit` のように値を別の語で取るグローバルオプションがあるため、正規表現ではなく語を順に見て判定する
- **`claude/settings.json`**: これまで一行で埋め込んでいた署名バイパスの禁止も同じスクリプトへ移し、テストが書ける形にした
- **`tasks/claude.yml`**: `~/.claude/` への symlink 配布に追加
- **`tasks/git.yml`**: 1Password の手動セットアップ手順に「メニューバーに常駐」を追記 (原因 3 への手当て)
- **`claude/tests/git_signing_preflight_test.py`** (新規): 21 件

## 確認方法

```bash
python3 claude/tests/git_signing_preflight_test.py
```

- 21 件 OK。偽の `op-ssh-sign` を差し込み、素通し・拒否・打ち切り・案内の出し分けを検証する
- 各テストは実装を一時的に壊して赤くなることを確認済み (バイパス検出 / 対象判定 / タイムアウトの打ち切り / 症状の切り分け / 署名ファイルの探し方)
- 実機では、1Password 停止中は「起動していない」と言い当てて即中断し、起動後は素通しして `git commit` が Verified (`%G?` = `G`) で通ることを確認した

## 補足

`settings.json` の `TMPDIR: /private/tmp` (#27) は現行のセッションには効いていない (実測 `TMPDIR=/var/folders/...`)。ただしその TMPDIR のままでも署名は通るため、今回の症状の原因ではなかった。別途整理する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)