### PR TITLE
fix(claude): runcat-metrics のテストの時限爆弾を外し、CI で流す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+
+# claude/ のスクリプトのテストは手元で流すしかなく、落ちたまま気付かれずに残ることが
+# あった (issue #36: fixture の絶対時刻が古びて 1 件赤いまま数日放置)。PR ごとに
+# 自動で流して、文書ルールではなく CI で拾う。
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  claude-scripts:
+    # 対象は macOS 前提のシェルスクリプト (bash 3.2 / BSD 系コマンド) なので、
+    # 実際に動く環境と同じ OS で流す
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: テストが存在することを確かめる
+        # discover はテストが 0 件でも成功するので、拾い漏れをここで落とす
+        run: ls claude/tests/*_test.py
+
+      - name: claude/tests を流す
+        run: python3 -m unittest discover -s claude/tests -p '*_test.py' -v

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ Temporary Items
 *.icloud
 
 # End of https://www.toptal.com/developers/gitignore/api/macos
+
+### Python ###
+# unittest discover が claude/tests/ に残すバイトコード
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ macOS の環境構築 (Ansible) と、Claude Code のグローバル設定の実
 - `vars/packages.yml` — インストール対象のパッケージ一覧
 - `claude/` — Claude Code のグローバル設定の実体。`tasks/claude.yml` が `~/.claude/` へ symlink する
 - `zshrc` — `~/.zshrc` の実体
+- `.github/workflows/test.yml` — `claude/tests/` を macOS runner で流す唯一の CI
 
 ## コマンド
 
@@ -21,9 +22,11 @@ macOS の環境構築 (Ansible) と、Claude Code のグローバル設定の実
 # 特定のタスクだけ流す
 ansible-playbook playbook_sillicon_mac.yml --tags claude
 
-# claude/ のスクリプトのテスト。CI は無いのでここが唯一の自動検証
+# claude/ のスクリプトのテスト (PR では .github/workflows/test.yml が同じものを流す)
+python3 -m unittest discover -s claude/tests -p '*_test.py' -v
+
+# 1 本だけ流す
 python3 claude/tests/runcat_metrics_test.py
-python3 claude/tests/git_signing_preflight_test.py
 ```
 
 ## 非自明なところ

--- a/claude/tests/runcat_metrics_test.py
+++ b/claude/tests/runcat_metrics_test.py
@@ -14,10 +14,20 @@ import tempfile
 import time
 import unicodedata
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import NamedTuple
 
 SCRIPT = Path(__file__).resolve().parent.parent / "runcat-metrics.py"
+
+
+def iso_in(seconds):
+    """今から seconds 秒後を、使用量エンドポイントと同じ ISO8601 (UTC) で返す。
+
+    リセット時刻を絶対時刻でベタ書きすると、その時刻を過ぎた日から残り時間が
+    出なくなってテストだけが落ちる (時限爆弾になる) ので、必ず今を基準に組む。
+    """
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
 
 
 class Cards(NamedTuple):
@@ -694,17 +704,20 @@ class UsageApiTest(ScriptTestCase):
     """
 
     # ユーザーの実レスポンスから、行の材料になる部分だけを写したもの
+    # (リセット時刻だけは、いつ流しても同じ結果になるよう今からの相対で組む)
+    SESSION_RESET = 2 * 3600         # 5 時間の枠が切り替わるまで
+    WEEKLY_RESET = 4 * 86400 + 3600  # 週間の枠が切り替わるまで
     RESPONSE = {
-        "five_hour": {"utilization": 0.0, "resets_at": "2026-07-28T09:50:00.712514+00:00"},
-        "seven_day": {"utilization": 18.0, "resets_at": "2026-08-02T00:59:59.712531+00:00"},
+        "five_hour": {"utilization": 0.0, "resets_at": iso_in(SESSION_RESET)},
+        "seven_day": {"utilization": 18.0, "resets_at": iso_in(WEEKLY_RESET)},
         "seven_day_opus": None,
         "limits": [
             {"kind": "session", "group": "session", "percent": 0,
-             "resets_at": "2026-07-28T09:50:00.712514+00:00", "scope": None, "is_active": False},
+             "resets_at": iso_in(SESSION_RESET), "scope": None, "is_active": False},
             {"kind": "weekly_all", "group": "weekly", "percent": 18,
-             "resets_at": "2026-08-02T00:59:59.712531+00:00", "scope": None, "is_active": True},
+             "resets_at": iso_in(WEEKLY_RESET), "scope": None, "is_active": True},
             {"kind": "weekly_scoped", "group": "weekly", "percent": 10,
-             "resets_at": "2026-08-02T00:59:59.712746+00:00",
+             "resets_at": iso_in(WEEKLY_RESET),
              "scope": {"model": {"id": None, "display_name": "Fable"}, "surface": None},
              "is_active": False},
         ],
@@ -743,11 +756,25 @@ class UsageApiTest(ScriptTestCase):
             # メニューバーは週間 (全モデル)
             self.assertEqual(cards.limits["metricsBarValue"], "18%")
 
+    def test_reset_time_in_the_past_leaves_the_percentage_alone(self):
+        """リセット時刻を過ぎた枠は使用率だけ出す (負の残り時間は出さない)。
+
+        枠が切り替わる瞬間の境界。実レスポンスを写した fixture が古びると
+        この経路に落ちるので、期待値をここで固定しておく。
+        """
+        response = dict(self.RESPONSE, limits=[
+            {"kind": "weekly_all", "percent": 18, "resets_at": iso_in(-60)},
+        ])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = self.stub(tmpdir, response)
+            cards = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
+            self.assertEqual(self.rows(cards.limits)["7d"]["formattedValue"], "18%")
+
     def test_scoped_label_comes_from_the_model_name(self):
         """モデル別の枠が増えても scope から拾える。"""
         response = dict(self.RESPONSE, limits=[
             {"kind": "weekly_scoped", "percent": 42,
-             "resets_at": "2026-08-02T00:59:59+00:00",
+             "resets_at": iso_in(self.WEEKLY_RESET),
              "scope": {"model": {"display_name": "Opus"}}},
         ])
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -758,7 +785,7 @@ class UsageApiTest(ScriptTestCase):
     def test_unknown_kinds_are_skipped(self):
         """知らない種別や percent の無い行は捨てる (増えても壊れない)。"""
         response = dict(self.RESPONSE, limits=[
-            {"kind": "weekly_all", "percent": 18, "resets_at": "2026-08-02T00:59:59+00:00"},
+            {"kind": "weekly_all", "percent": 18, "resets_at": iso_in(self.WEEKLY_RESET)},
             {"kind": "brand_new_kind", "percent": 5},
             {"kind": "session"},  # percent が無い
             {"kind": "weekly_scoped", "percent": 7, "scope": {"model": {}}},  # 名前が無い
@@ -779,7 +806,7 @@ class UsageApiTest(ScriptTestCase):
             # 応答の中身を差し替えても、控えが新しいうちは読み直さない
             self.stub(tmpdir, {"limits": [
                 {"kind": "weekly_all", "percent": 99,
-                 "resets_at": "2026-08-02T00:59:59+00:00"}]})
+                 "resets_at": iso_in(self.WEEKLY_RESET)}]})
             cards = self.run_script(self.payload(), workdir=tmpdir, usage_url=url)
             rows = self.rows(cards.limits)
             self.assertTrue(rows["7d"]["formattedValue"].startswith("18% · "),


### PR DESCRIPTION
Fixes #36

## 目的

`claude/tests/runcat_metrics_test.py` の `test_all_three_limits_are_rendered` が
落ちていた原因を潰し、同じ落ち方が今後 CI で拾えるようにする。

## 原因

実装ではなく fixture の側。`UsageApiTest.RESPONSE` はユーザーの実レスポンスを
リセット時刻ごと写しており、`5h` の `2026-07-28` が今日にはもう過去になっていた。

実装 (`claude/runcat-metrics.py:295`) は `fmt_duration` が負の残り時間に `None` を
返す作りで、リセット済みの枠には ` · Xh left` を添えない。これが正しい振る舞いなので、
直すのは fixture。なお `7d` の `2026-08-02` も同じ理由で 2 日後に落ちる状態だった。

## 変更点

- fixture のリセット時刻を今からの相対 (`iso_in`) で組み直す。絶対時刻を書かない理由は
  ヘルパーの docstring に残した
- リセット時刻を過ぎた枠が使用率だけを出すことを回帰テストで固定
  (`test_reset_time_in_the_past_leaves_the_percentage_alone`)
- `.github/workflows/test.yml` を追加。push (main) と PR で `claude/tests` を
  macOS runner 上の `unittest discover` で流す。テスト 0 件でも discover が成功する
  ため、先に `ls claude/tests/*_test.py` で拾い漏れを落とす
- CLAUDE.md のコマンドを discover 一発へ更新 (個別列挙は `git_safety_guard_test.py` が
  漏れていた)。discover が残す `__pycache__/` を gitignore

## 確認方法

```bash
python3 -m unittest discover -s claude/tests -p '*_test.py' -v
```

- 修正前: 1 件 FAIL (`AssertionError: False is not true : 0%`)
- 修正後: 91 件 OK
- 新しい回帰テストは、実装の負値ガード (`fmt_duration` の `seconds < 0`) を一時的に
  外すと赤くなることを確認済み (`- 18% · 1m left` / `+ 18%`)
- CI 自体はこの PR のチェックが green になることで確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)