### PR TITLE
feat(claude): ADR の記録運用と作業ログの外部化をチェック項目化

### DIFF
--- a/claude/repo-standards.json
+++ b/claude/repo-standards.json
@@ -78,8 +78,20 @@
       "level": "recommended",
       "applies_to": ["all"],
       "check": { "type": "builtin", "name": "adr_exists" },
-      "why": "設計判断の記録 (メモリリセット耐性の中核)。既に過半のリポで docs/decisions/ を採用済み",
+      "why": "設計判断の記録 (メモリリセット耐性の中核)。既に過半のリポで docs/decisions/ を採用済み。ディレクトリだけ作って空のまま放置されると記録の実体が無い",
       "fix": "docs/decisions/ を作り、状態 / 文脈 / 決定 / 影響の 4 節で ADR を書き始める"
+    },
+    {
+      "id": "adr-covers-decisions",
+      "layer": "repo",
+      "level": "required",
+      "applies_to": ["all"],
+      "check": {
+        "type": "llm",
+        "prompt": "docs/decisions/ の ADR 一覧と直近 30 コミット (git log --oneline -30) を突き合わせ、(1) 設計判断を伴う変更 (feat / refactor / 依存や CI の方針変更) で ADR が残っていないものが無いか、(2) 既存 ADR の決定内容が現在の実装と乖離していないか、(3) 各 ADR が 状態 / 文脈 / 決定 / 影響 の 4 節を保っているか を判定する。ADR が 0 件なら adr-exists 側の指摘に委ねてこの項目は skip とする"
+      },
+      "why": "ADR はディレクトリの存在ではなく「重要な意思決定がそこに残り続けているか」で価値が決まる。存在チェックでは書かれなくなった劣化を検出できない",
+      "fix": "漏れている決定を ADR に追記し、実装と乖離した ADR は状態を 廃止 / 置換 に更新する"
     },
     {
       "id": "changelog-exists",
@@ -170,6 +182,18 @@
       "check": { "type": "builtin", "name": "pr_template_exists" },
       "why": "PR 本文 (目的・変更点・確認方法) を丁寧に書く規約の受け皿",
       "fix": ".github/pull_request_template.md を追加する"
+    },
+    {
+      "id": "work-log-externalized",
+      "layer": "repo",
+      "level": "required",
+      "applies_to": ["all"],
+      "check": {
+        "type": "llm",
+        "prompt": "進行中の作業がセッションの記憶に依存していないかを判定する。(1) 直近 30 日にコミットがあるのに open Issue が 0 件でないか (gh issue list --state open)、(2) 進行中の Issue / PR に調査の中間所見や検証ログのコメントが積まれているか、(3) 中長期の計画 (ロードマップ・マイルストーン・docs/ 配下の計画文書) が置かれ更新されているか。記憶ゼロの状態でこれらを読むだけで再開できるかを基準にする。直近 30 日にコミットが無い (動いていない) リポは skip とする"
+      },
+      "why": "セッションの記憶は常にリセットされる前提。恒久的な置き場に記録が無いと、状況・残タスク・中間所見・検証ログが失われて再開できない (グローバル CLAUDE.md の中核規約)",
+      "fix": "残タスクと課題を Issue に起票し、進行中の調査結果は該当 Issue / PR にコメントで追記する。中長期の計画は docs/ かマイルストーンに置く"
     },
     {
       "id": "editorconfig-rejected",

--- a/claude/tests/repo_standards_test.py
+++ b/claude/tests/repo_standards_test.py
@@ -68,6 +68,17 @@ class RepoStandardsTestCase(unittest.TestCase):
                     missing, f"check.type={check['type']} に必須の {missing} が無い"
                 )
 
+    def test_check_fields_not_blank(self):
+        # 必須フィールドが空文字でも存在チェックだけは通ってしまう。空の prompt は
+        # LLM 判定が何も判定できないまま ok に見え、空の path は全ファイルに一致する
+        for item in self.items:
+            check = item["check"]
+            for field in CHECK_REQUIRED_FIELDS[check["type"]]:
+                with self.subTest(id=item["id"], field=field):
+                    self.assertTrue(
+                        str(check[field]).strip(), f"check.{field} が空"
+                    )
+
     def test_applies_to_resolves(self):
         kind_ids = {k["id"] for k in self.kinds} | {"all"}
         for item in self.items:


### PR DESCRIPTION
## 目的

グローバル CLAUDE.md の中核規約のうち、repo-standards.json が**受け皿の存在しか強制していなかった 2 領域**を項目化する。

- 「重要な意思決定を ADR に残す」→ `adr-exists` は `docs/decisions/` の**ディレクトリ存在だけ**を見るため、空ディレクトリでも ok になっていた
- 「メモリは揮発する前提で作業ログ・計画を Issue / ロードマップ / docs に記録する」→ **該当項目が無かった**。`issue-template-exists` はテンプレートの存在を見るだけで、運用されているかは不問

どちらも「受け皿があるか」ではなく「実際に運用されているか」が本質なので、機械判定では拾えず `check.type: llm` を選んだ。

## 変更点

| 項目 | level | type | 判定内容 |
|---|---|---|---|
| `adr-covers-decisions` (新規) | required | llm | ADR 一覧と直近 30 コミットを突き合わせ、(1) 設計判断を伴う変更で ADR が残っていないもの、(2) 実装との乖離、(3) 状態/文脈/決定/影響の 4 節の体裁を判定。ADR 0 件なら `adr-exists` の指摘に委ねて skip |
| `work-log-externalized` (新規) | required | llm | (1) 直近 30 日にコミットがあるのに open Issue 0 件でないか、(2) 進行中の Issue / PR に中間所見・検証ログが積まれているか、(3) 計画ドキュメントが更新されているか。動いていないリポは skip |
| `adr-exists` (既存) | recommended | builtin | `why` に「ディレクトリだけ作って空のまま放置されると記録の実体が無い」を追記 |

項目数は 48 → 50。

### テスト

`check` の必須フィールドが**空文字**でないことの検証を追加した。既存の `test_check_required_fields` はキーの存在しか見ておらず、空の `prompt` は LLM 判定が何も判定できないまま ok に見え、空の `path` は全ファイルに一致してしまう。

## 確認方法

```bash
python3 -m unittest discover -s claude/tests -p '*_test.py'
```

- 全 101 テスト green
- 新テストの効きを確認済み: `adr-covers-decisions` の `prompt` を空にすると `check.prompt が空` で赤くなる
- 既存の `test_required_items_have_fix` が新項目に効くことも確認済み: `work-log-externalized` の `fix` を空にすると赤くなる

## 消費側との関係

`check.type: llm` のみの追加なので、[claude-plugins の repo-standards プラグイン](https://github.com/shinyaoguri/claude-plugins/tree/main/plugins/repo-standards) との builtin 名の契約は変えていない (プラグイン側は llm 項目を `status: manual` として素通しし、SKILL.md 側で判定する)。

`adr-exists` の判定強化 (空ディレクトリを ng にする `builtin_adr_exists` の変更) はプラグイン側の別 PR で出す。ADR 0006 のとおり本 PR (正本側) を先にマージする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)