### PR TITLE
feat(claude): Gyazo MCP サーバーを Claude Code へ登録する

### DIFF
--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -101,3 +101,27 @@
   loop: "{{ claude_global_skills.files }}"
   loop_control:
     label: "{{ item.path | basename }}"
+
+# Gyazo MCP サーバー (macOS 版) を Claude Code の user スコープへ登録する。
+# スクリーンショットを Gyazo にアップロードして URL を得るために使う
+# (Issue や PR に画像を貼るときにリポジトリへ画像をコミットせずに済む)。
+# バイナリは cask の gyazo が入れる。要 Gyazo v9.9.0 以降。
+# 参照: https://help-ja.gyazo.com/ の「Gyazo MCP サーバー（開発者向けプレビュー版）」
+- name: Check Gyazo MCP server binary
+  ansible.builtin.stat:
+    path: "{{ gyazo_mcp_server_path }}"
+  register: gyazo_mcp_bin
+  vars:
+    gyazo_mcp_server_path: /Applications/Gyazo Menu.app/Contents/Helpers/cli-tool/GyazoMacMCPServer
+
+# claude mcp add は登録済みなら "already exists" を返して rc=0 で終わるので、
+# stdout を見て changed を判定するだけでよい (冪等)
+- name: Register Gyazo MCP server for Claude Code
+  ansible.builtin.command:
+    cmd: >-
+      claude mcp add gyazo-mac
+      "/Applications/Gyazo Menu.app/Contents/Helpers/cli-tool/GyazoMacMCPServer"
+      -s user
+  register: gyazo_mcp_add
+  changed_when: "'Added stdio MCP server' in gyazo_mcp_add.stdout"
+  when: gyazo_mcp_bin.stat.exists


### PR DESCRIPTION
## 目的

Issue や PR にスクリーンショットを貼るとき、**GitHub には画像添付の公開 API が無い** (web UI のドラッグ&ドロップは内部エンドポイント)。そのため直前まではリポジトリへ画像をコミットして raw URL で参照する方針だったが、**リポジトリの容量を圧迫する**。

[Gyazo MCP サーバー (開発者向けプレビュー版)](https://help-ja.gyazo.com/) を使えば、キャプチャからアップロードまでが 1 ステップで済み、得られた URL を貼るだけでよくなる。

## 変更点

`tasks/claude.yml` に MCP 登録タスクを追加。

- バイナリは cask の `gyazo` が入れるので**新規の依存は増えない** (`vars/packages.yml` に既に含まれている)
- `claude mcp add` は登録済みなら `already exists` を返して **rc=0 で終わる**ため、stdout を見て `changed` を判定するだけで冪等になる (手元で再実行して確認済み)
- アプリ未導入のマシンでは `stat` で存在を確認して skip する

## 提供されるツール (手元で確認)

| ツール | 機能 |
|---|---|
| `gyazo_capture_and_upload_region` | 範囲選択キャプチャ + アップロード |
| `gyazo_capture_and_upload_primary_screen` | 全画面キャプチャ + アップロード |
| `gyazo_capture_and_upload_window` | ウィンドウ指定キャプチャ + アップロード |
| `gyazo_list_capturable_windows` | ウィンドウ一覧 (WindowId / アプリ名 / タイトル) |
| `gyazo_get_captured_image` | アップロード完了後に画像と URL を取得 |

## 確認方法

```bash
ansible-playbook playbook_sillicon_mac.yml --tags claude --syntax-check
python3 -m unittest discover -s claude/tests -p '*_test.py'
```

- syntax-check green、既存テスト 101 件 green
- 手元では `claude mcp add ... -s user` を実行済みで、`claude mcp list` が `gyazo-mac: ✔ Connected` を返すことと、MCP プロトコルで上記 5 ツールが列挙されることを確認した
- 環境は Gyazo v10.12.0 (要件は v9.9.0 以降)

## 注意点

- **開発者向けプレビュー版**なので仕様変更の可能性があり、公式サポート対象外
- `gyazo_get_captured_image` は URL と**画像そのもの**を返す。画像の読み込みはトークンを消費するので、URL が目的のときも呼び出しは 1 回に留める運用にする
- 動画キャプチャは非対応

## 関連

利用側の規約 (どういうときにスクショを貼るか) は shinyaoguri/claude-plugins の CLAUDE.md 側で更新する。