### PR TITLE
fix(claude): Gyazo MCP 登録タスクの 2 回目以降の失敗を止める

### DIFF
--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -114,8 +114,8 @@
   vars:
     gyazo_mcp_server_path: /Applications/Gyazo Menu.app/Contents/Helpers/cli-tool/GyazoMacMCPServer
 
-# claude mcp add は登録済みなら "already exists" を返して rc=0 で終わるので、
-# stdout を見て changed を判定するだけでよい (冪等)
+# claude mcp add は登録済みだと rc=1 で終わり "already exists" を stderr に出す。
+# 2 回目以降を失敗にしないよう failed_when で除外する (これが冪等性の要)
 - name: Register Gyazo MCP server for Claude Code
   ansible.builtin.command:
     cmd: >-
@@ -124,4 +124,7 @@
       -s user
   register: gyazo_mcp_add
   changed_when: "'Added stdio MCP server' in gyazo_mcp_add.stdout"
+  failed_when: >-
+    gyazo_mcp_add.rc != 0
+    and 'already exists' not in (gyazo_mcp_add.stderr | default(''))
   when: gyazo_mcp_bin.stat.exists


### PR DESCRIPTION
## 症状

`ansible-playbook playbook_sillicon_mac.yml --tags claude` が失敗する。

```
TASK [Register Gyazo MCP server for Claude Code] *******************************
fatal: [localhost]: FAILED! => {"rc": 1, "stderr": "MCP server gyazo-mac already exists in user config", "stdout": ""}
PLAY RECAP
localhost : ok=9  changed=0  failed=1
```

## 原因

`claude mcp add` は**登録済みだと rc=1 で終わり**、`already exists` を **stderr** に出す。`changed_when` だけでは 2 回目以降が fatal になる。

#43 のコメントに「rc=0 で終わる」と書いたのは**検証の誤り**。手元では

```bash
claude mcp add ... 2>&1 | tail -2; echo "(exit=$?)"
```

で確認しており、**パイプの最後のコマンド (`tail`) の終了コード**を見ていた。正しく取り直すと:

```
$ claude mcp add ... >/dev/null 2>/tmp/err.txt; echo "rc=$?"
rc=1
stderr: MCP server gyazo-mac already exists in user config
```

## 修正

`failed_when` で `already exists` を除外する。これが冪等性の要になる。

```yaml
  failed_when: >-
    gyazo_mcp_add.rc != 0
    and 'already exists' not in (gyazo_mcp_add.stderr | default(''))
```

## 確認方法

**両方の経路を実機で確認した** (今回のバグは 2 回目の実行でしか出なかったため)。

| 状態 | 結果 |
|---|---|
| 未登録から (`claude mcp remove` 後) | `changed: [localhost]` — 登録される |
| 登録済みで再実行 | `ok: [localhost]` / `failed=0 changed=0` — 冪等 |

```
PLAY RECAP
localhost : ok=10  changed=0  unreachable=0  failed=0  skipped=2
```