### PR TITLE
feat(claude): 自作 marketplace (shinyaoguri) とプラグインを settings.json で宣言する

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -52,7 +52,10 @@
   },
   "enabledPlugins": {
     "swift-lsp@claude-plugins-official": true,
-    "cloudflare@cloudflare": true
+    "cloudflare@cloudflare": true,
+    "metaphor-sketch@shinyaoguri": true,
+    "metaphor-contrib@shinyaoguri": true,
+    "repo-standards@shinyaoguri": true
   },
   "extraKnownMarketplaces": {
     "cosense-cli": {
@@ -65,6 +68,13 @@
       "source": {
         "source": "github",
         "repo": "cloudflare/skills"
+      },
+      "autoUpdate": true
+    },
+    "shinyaoguri": {
+      "source": {
+        "source": "github",
+        "repo": "shinyaoguri/claude-plugins"
       },
       "autoUpdate": true
     }


### PR DESCRIPTION
## 目的

shinyaoguri/claude-plugins (自作 plugin marketplace) の登録と自作プラグインのインストールが各マシンでの手動操作 (`/plugin marketplace add` など) に依存しており、新マシンで再現されない。settings.json での宣言に一本化し、セットアップだけで全マシンが同じ状態になるようにする。

## 変更点

- `extraKnownMarketplaces` に `shinyaoguri` (github: shinyaoguri/claude-plugins、autoUpdate) を追加
- `enabledPlugins` に `metaphor-sketch@shinyaoguri` / `metaphor-contrib@shinyaoguri` / `repo-standards@shinyaoguri` を追加

## 確認方法

- `jq empty claude/settings.json` — JSON として妥当
- `python3 -m unittest discover -s claude/tests -p '*_test.py'` — 101 件 green (本 PR とは独立だが退行なし)
- 実機は ~/.claude/settings.json が本ファイルへの symlink のため、マージ後に main を pull すれば次セッションから有効

🤖 Generated with [Claude Code](https://claude.com/claude-code)