### PR TITLE
fix(claude): ブランチ命名の GitHub 強制 (gh-branch-name-pattern) を標準から外す

### DIFF
--- a/claude/repo-standards.json
+++ b/claude/repo-standards.json
@@ -399,15 +399,6 @@
       "fix": "target: tag / include: refs/tags/v* で deletion + non_fast_forward + update の ruleset を作る"
     },
     {
-      "id": "gh-branch-name-pattern",
-      "layer": "github",
-      "level": "recommended",
-      "applies_to": ["all"],
-      "check": { "type": "builtin", "name": "branch_name_pattern" },
-      "why": "ブランチ命名 `<type>/<短い説明>` は規約として明文化されているのに、どのリポでも強制されていなかった",
-      "fix": "ruleset に branch_name_pattern を追加する。bot と Claude Code のブランチを必ず許可する (例: ^(feat|fix|docs|refactor|test|chore|ci|perf|build|dependabot|claude)/ — dependabot/... と claude/... を弾くと PR が作れなくなる)"
-    },
-    {
       "id": "gh-vulnerability-alerts",
       "layer": "github",
       "level": "required",


### PR DESCRIPTION
## 目的

`repo-standards.json` の `gh-branch-name-pattern` は、全リポジトリに GitHub ruleset での
ブランチ命名強制を求める recommended 項目だった。対象が主に個人リポジトリであり、
ブランチ命名は グローバル CLAUDE.md の規約と PR 運用で足りている。全リポに ruleset を
足させる運用コストに見合わないため、標準そのものから削除する。

## 変更点

- `claude/repo-standards.json` から `gh-branch-name-pattern` 項目を削除

消費者側 (shinyaoguri/claude-plugins の repo-standards プラグイン) の
`builtin_branch_name_pattern` も同時に削除する (別 PR)。正本から項目が消えれば
プラグイン側の builtin は呼ばれなくなるため、この PR を先にマージしても
古いプラグインで異常は出ない。

## 確認方法

- `jq -e . claude/repo-standards.json` → 妥当な JSON
- `python3 -m unittest discover -s claude/tests -p 'repo_standards_test.py'` → 10 tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)