### PR TITLE
feat(claude): プロビジョニングの変更内容を実行前に予告するフックを足す

### DIFF
--- a/claude/provisioning-preflight.sh
+++ b/claude/provisioning-preflight.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Claude Code の PreToolUse フック: プロビジョニングを流す前に、何が変わるかを先に見る。
+#
+# git-safety-guard.sh は git の破壊的操作しか見ておらず、ansible のように
+# **マシンの状態をまとめて書き換える**コマンドは素通りしていた。実際、宣言と実態が
+# ずれたまま playbook を流し、user.email が意図せず書き換わった事故がある
+# (気付いたのは changed の数を目で追っていたからで、検出が運に依存していた)。
+#
+# ansible は冪等性を前提にしているので --check --diff が正確な予告になる。先に
+# dry-run し、変わるものが無ければ黙って通す。**人間を呼ぶのは実際に何かが変わるとき
+# だけ**で、流し直すだけの実行は止めない。
+#
+# 予告を組み立てられない形 (複合コマンド・dry-run の失敗・時間切れ) は ask に倒す。
+# 判定不能を安全側に寄せるのは git-safety-guard.sh と同じ方針。
+#
+# 契約: stdin に PreToolUse の JSON。素通しは無出力 + 終了コード 0。
+# 呼び出し口は settings.json の hooks.PreToolUse、テストは
+# claude/tests/provisioning_preflight_test.py (python3 で直接実行)。
+
+set -uo pipefail
+
+# dry-run に許す秒数。settings.json 側の timeout より短くしておく
+# (フックごと殺されると判断を返せないため)。実測: --tags git で約 3 秒、全体で約 13 秒。
+# テストから短く上書きするためだけに環境変数を見る。
+readonly DRY_RUN_LIMIT=${PROVISIONING_PREFLIGHT_LIMIT:-25}
+
+decide() { # $1=allow|deny|ask  $2=理由
+  jq -n --arg d "$1" --arg r "$2" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: $d, permissionDecisionReason: $r}}'
+  exit 0
+}
+
+payload=$(cat)
+command=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+[ -n "$command" ] || exit 0
+
+# 対象は ansible-playbook のみ。コマンド区切りで割ってから**先頭の語**を見る
+# (`echo ansible-playbook` のように引数として現れるだけのものを拾わないため)。
+printf '%s' "$command" | tr ';&|' '\n' |
+  grep -qE '^[[:space:]]*ansible-playbook([[:space:]]|$)' || exit 0
+# dry-run そのものは状態を変えないので素通しする (二重に走らせない)。
+printf '%s' "$command" | grep -qE '(^|[[:space:]])(--check|-C)([[:space:]]|$)' && exit 0
+
+# `cd <dir> && ansible-playbook …` は頻出なので、cd 先を取り出して残りを予告に回す。
+workdir="."
+rest="$command"
+if printf '%s' "$command" | grep -qE '^[[:space:]]*cd[[:space:]]+[^&;|]+&&'; then
+  workdir=$(printf '%s' "$command" |
+    sed -E 's/^[[:space:]]*cd[[:space:]]+([^&;|]+)&&.*/\1/' | sed -E 's/[[:space:]]+$//')
+  rest=$(printf '%s' "$command" | sed -E 's/^[[:space:]]*cd[[:space:]]+[^&;|]+&&[[:space:]]*//')
+fi
+
+# ここから先は「ansible-playbook 単体」でないと予告を組み立てられない。
+if printf '%s' "$rest" | grep -qE '[;&|]'; then
+  decide ask "ansible-playbook が他のコマンドと繋がっているため、変更内容を先に見ることができない。
+
+ansible-playbook だけを単体で実行すれば、このフックが --check --diff で予告する。
+そのうえで実行するなら、何が変わるのかをユーザーへ伝えて判断を仰ぐ。"
+fi
+
+# --- dry-run で予告を取る ---------------------------------------------------
+report=$(mktemp)
+trap 'rm -f "$report"' EXIT
+
+(cd "$workdir" 2>/dev/null && eval "$rest --check --diff") >"$report" 2>&1 &
+runner=$!
+
+waited=0
+while kill -0 "$runner" 2>/dev/null; do
+  if [ "$waited" -ge "$DRY_RUN_LIMIT" ]; then
+    kill -TERM "$runner" 2>/dev/null
+    wait "$runner" 2>/dev/null
+    decide ask "変更内容の事前確認 (--check) が ${DRY_RUN_LIMIT} 秒で終わらなかったため、何が変わるか分からない。
+
+--tags で対象を絞れば予告が早く返る。範囲を絞れないなら、実行前にユーザーへ確認する。"
+  fi
+  sleep 1
+  waited=$((waited + 1))
+done
+wait "$runner"
+dry_run_status=$?
+
+if [ "$dry_run_status" -ne 0 ]; then
+  decide ask "変更内容の事前確認 (--check) が失敗したため、何が変わるか分からない。
+
+$(tail -20 "$report")
+
+このまま流すと予期しない変更が入りうる。原因を確かめるか、ユーザーへ確認する。"
+fi
+
+# PLAY RECAP の changed=N が予告。読めなければ判定不能として ask に倒す。
+changed=$(grep -oE 'changed=[0-9]+' "$report" | tail -1 | cut -d= -f2)
+if [ -z "$changed" ]; then
+  decide ask "変更内容の事前確認 (--check) の結果を読み取れなかった (PLAY RECAP が無い)。
+
+$(tail -20 "$report")"
+fi
+
+# 変わるものが無いなら人間を呼ばない (冪等な流し直し)。
+[ "$changed" -eq 0 ] && exit 0
+
+decide ask "この実行で ${changed} 件が変更される。**中身を確かめてから**実行する。
+
+$(grep -E '^(TASK \[|changed: |--- before|\+\+\+ after|@@|[-+][^-+])' "$report" | head -60)
+
+確かめること:
+- 変更が意図したものか (宣言と実際の設定がずれていると、意図せず宣言側へ引き戻される)
+- 引き戻される値が今の運用より古くないか (ずれているなら、直すべきは playbook 側かもしれない)
+
+意図しない変更が混ざっているなら、実行せずユーザーへ伝える。"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -45,10 +45,20 @@
             "command": "~/.claude/git-safety-guard.sh",
             "timeout": 10,
             "statusMessage": "git 操作の安全確認中"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/provisioning-preflight.sh",
+            "timeout": 30,
+            "statusMessage": "プロビジョニングの変更内容を事前確認中"
           }
         ]
       }
     ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/runcat-metrics.py"
   },
   "enabledPlugins": {
     "swift-lsp@claude-plugins-official": true,
@@ -78,10 +88,6 @@
       },
       "autoUpdate": true
     }
-  },
-  "statusLine": {
-    "type": "command",
-    "command": "~/.claude/runcat-metrics.py"
   },
   "language": "japanese",
   "tui": "fullscreen",

--- a/claude/tests/provisioning_preflight_test.py
+++ b/claude/tests/provisioning_preflight_test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""claude/provisioning-preflight.sh のテスト。
+
+実物の ansible を回すと遅く、結果がマシンの状態に依存してしまうので、PATH の先頭に
+偽の `ansible-playbook` を置いて出力を固定する。検証したいのは「予告をどう読んで
+どう判断するか」であって ansible の挙動ではない。
+
+    python3 claude/tests/provisioning_preflight_test.py
+"""
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "provisioning-preflight.sh"
+
+RECAP_NO_CHANGE = "localhost : ok=7 changed=0 unreachable=0 failed=0"
+RECAP_WITH_CHANGE = "localhost : ok=16 changed=1 unreachable=0 failed=0"
+DIFF_BODY = """TASK [Set Git global email] ****
+--- before
++++ after
+@@ -1 +1 @@
+-36407060+shinyaoguri@users.noreply.github.com
++ogrsny@gmail.com
+
+changed: [localhost]
+"""
+
+
+class HookTestCase(unittest.TestCase):
+    def setUp(self):
+        self.workdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.workdir.cleanup)
+        self.root = Path(self.workdir.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+
+    def fake_ansible(self, body, exit_code=0):
+        """偽 ansible-playbook を PATH に置く。--check のときだけ body を出す。"""
+        script = self.bin / "ansible-playbook"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            'if ! printf "%s" "$*" | grep -q -- "--check"; then\n'
+            '  echo "本番実行された (テストの想定外)" >&2; exit 9\n'
+            "fi\n"
+            f"cat <<'EOF'\n{body}\nEOF\n"
+            f"exit {exit_code}\n"
+        )
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+
+    def slow_ansible(self, seconds):
+        script = self.bin / "ansible-playbook"
+        script.write_text(f"#!/usr/bin/env bash\nsleep {seconds}\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+
+    def run_hook(self, command):
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin}:{env['PATH']}"
+        env["PROVISIONING_PREFLIGHT_LIMIT"] = "2"   # 時間切れの検証を待たずに済ませる
+        return subprocess.run(
+            [str(SCRIPT)],
+            input=json.dumps({"tool_name": "Bash", "tool_input": {"command": command}}),
+            capture_output=True, text=True, cwd=self.root, env=env, timeout=60,
+        )
+
+    def assert_allowed(self, result):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "", "素通しのはずが出力があった")
+
+    def assert_decision(self, result, expected):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = json.loads(result.stdout)["hookSpecificOutput"]
+        self.assertEqual(output["hookEventName"], "PreToolUse")
+        self.assertEqual(output["permissionDecision"], expected)
+        return output["permissionDecisionReason"]
+
+
+class ForecastTest(HookTestCase):
+    """dry-run の結果で判断する。変わるものが無ければ人間を呼ばない。"""
+
+    def test_no_change_passes_silently(self):
+        """冪等な流し直しは止めない。"""
+        self.fake_ansible(RECAP_NO_CHANGE)
+        self.assert_allowed(self.run_hook("ansible-playbook playbook.yml --tags git"))
+
+    def test_change_is_reported_with_diff(self):
+        """変わるものがあるときだけ、中身を添えて判断を返す。"""
+        self.fake_ansible(DIFF_BODY + RECAP_WITH_CHANGE)
+        reason = self.assert_decision(
+            self.run_hook("ansible-playbook playbook.yml --tags git"), "ask"
+        )
+        self.assertIn("1 件が変更される", reason)
+        self.assertIn("noreply", reason)   # 実際に消える値が見えること
+        self.assertIn("Set Git global email", reason)
+
+    def test_dry_run_failure_asks(self):
+        """予告できなかったものは通さない。"""
+        self.fake_ansible("ERROR! playbook not found", exit_code=1)
+        reason = self.assert_decision(self.run_hook("ansible-playbook nope.yml"), "ask")
+        self.assertIn("失敗", reason)
+
+    def test_unreadable_recap_asks(self):
+        """PLAY RECAP が無ければ changed の数が分からない。"""
+        self.fake_ansible("何かの出力だが RECAP が無い")
+        reason = self.assert_decision(self.run_hook("ansible-playbook playbook.yml"), "ask")
+        self.assertIn("読み取れなかった", reason)
+
+    def test_timeout_asks(self):
+        """時間切れも「分からない」なので通さない。"""
+        self.slow_ansible(30)
+        reason = self.assert_decision(self.run_hook("ansible-playbook playbook.yml"), "ask")
+        self.assertIn("秒で終わらなかった", reason)
+
+
+class CommandShapeTest(HookTestCase):
+    """予告を組み立てられる形かどうかを先に見る。"""
+
+    def test_cd_prefix_is_supported(self):
+        """`cd <dir> && ansible-playbook …` は頻出。cd 先で予告する。"""
+        self.fake_ansible(RECAP_NO_CHANGE)
+        target = self.root / "setup"
+        target.mkdir()
+        self.assert_allowed(
+            self.run_hook(f"cd {target} && ansible-playbook playbook.yml --tags git")
+        )
+
+    def test_compound_command_asks(self):
+        """他のコマンドと繋がっていると、そのままでは予告できない。"""
+        self.fake_ansible(RECAP_NO_CHANGE)
+        reason = self.assert_decision(
+            self.run_hook("ansible-playbook playbook.yml | tee log.txt"), "ask"
+        )
+        self.assertIn("繋がっている", reason)
+
+    def test_explicit_check_passes(self):
+        """dry-run そのものは状態を変えないので素通し (二重に走らせない)。"""
+        self.assert_allowed(self.run_hook("ansible-playbook playbook.yml --check --diff"))
+
+    def test_unrelated_commands_pass(self):
+        for command in (
+            "ls -la",
+            "git status --short",
+            "brew install jq",
+            "echo ansible-playbook",   # 語として現れるだけの実行しない文字列
+        ):
+            with self.subTest(command):
+                self.assert_allowed(self.run_hook(command))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -37,6 +37,7 @@
       - runcat-metrics.py
       - git-signing-preflight.sh
       - git-safety-guard.sh
+      - provisioning-preflight.sh
 
 - name: Create ~/.claude directory
   ansible.builtin.file:


### PR DESCRIPTION
## 背景・きっかけ

#57 で git の破壊的操作には可逆性の判定が入ったが、**ガードの守備範囲は git だけ**だった。ansible のようにマシンの状態をまとめて書き換えるコマンドは素通りする。

実際に事故が起きている。`tasks/git.yml` の宣言（`ogrsny@gmail.com`）と実際の設定（noreply）がずれたまま playbook を流し、`user.email` が意図せず書き換わった。気付いたのは `changed=4` という数を目で追っていたからで、**検出が運に依存していた**。見落としていれば以降のコミットすべてに実アドレスが載っていた。

## 変更点

ansible は冪等性を前提にしているので `--check --diff` が正確な予告になる。実行前に dry-run し、**変わるものが無ければ黙って通す**。人間を呼ぶのは実際に何かが変わるときだけで、冪等な流し直しは止めない。

| ケース | 判断 |
|---|---|
| dry-run が `changed=0` | 素通し（人間を呼ばない） |
| dry-run が `changed>0` | `ask` + 差分を提示 |
| 複合コマンド / dry-run 失敗 / RECAP 無し / 時間切れ | `ask`（判定不能は安全側） |
| `--check` が既に付いている | 素通し（二重に走らせない） |

- 対象は `ansible-playbook` のみ。コマンド区切りで割ってから**先頭の語**を見るので、`echo ansible-playbook` のように引数として現れるだけのものは拾わない
- `cd <dir> && ansible-playbook …` は頻出なので cd 先で予告する
- dry-run の制限時間は 25 秒（実測: `--tags git` で約 3 秒、全体で約 13 秒）。`settings.json` 側の timeout は 30 秒にしてフックごと殺されないようにした

判定不能を `ask` に倒す方針は `git-safety-guard.sh` と同じで、**操作の種類ではなく実際に何が起きるかで判断する**という #57 の原理を git の外へ広げた形。

## 確認方法

事故当時の状態を再現し、本番のフック（symlink 経由）にかけた:

```
A) 差分なしの実行            → 素通し (人間を呼ばない)
B) user.email がずれた状態   → ask
     この実行で 1 件が変更される。**中身を確かめてから**実行する。
     TASK [Set Git global email] ****
     @@ -1 +1 @@
     -36407060+shinyaoguri@users.noreply.github.com
     +ogrsny@gmail.com
```

消える値まで提示されるので、実行前に「引き戻されると困る」と判断できる。`--check` が状態を変えないことも、実行後に値が noreply のままであることで確認済み。

- `python3 claude/tests/provisioning_preflight_test.py` — 9 本、全 green。偽の `ansible-playbook` を PATH に置いて出力を固定し、判断のロジックだけを決定論的に検証する（実物の ansible は遅く、結果がマシンの状態に依存するため）
- 他のフックのテスト（git-safety-guard / signing-preflight / repo-standards / runcat-metrics）にも影響が無いことを確認

## 補足

`claude/settings.json` の `statusLine` はキー順が Claude Code の書き戻しで動いていたぶんを同時に取り込んだ（内容は同一）。

守備範囲の限界も明記しておく。これは **ansible という一点を塞ぐ対策**であり、`Write` による git 外ファイルの上書きのように dry-run を持たない操作は依然カバーされない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)