### PR TITLE
fix(claude): gh-delete-branch-on-merge の why を実態に合わせる (fetch -p ではローカルは消えない)

### DIFF
--- a/claude/repo-standards.json
+++ b/claude/repo-standards.json
@@ -257,7 +257,7 @@
         "jq": ".delete_branch_on_merge",
         "expect": "true"
       },
-      "why": "merge 後のブランチ掃除 (git fetch -p) とセットの運用",
+      "why": "merge 後のブランチ掃除とセットの運用。git fetch -p が消すのは remote-tracking 参照だけなので、ローカルブランチは upstream:track == [gone] を手がかりに掃除する (env-doctor の env-git-fetch-prune / env-git-gone-alias)",
       "fix": "gh api -X PATCH repos/{repo} -F delete_branch_on_merge=true"
     },
     {


### PR DESCRIPTION
## 背景

`gh-delete-branch-on-merge` の `why` は「merge 後のブランチ掃除 (git fetch -p) とセットの運用」と書いていたが、**`git fetch -p` が消すのは remote-tracking 参照だけで、ローカルブランチは残る**。

この記述は squash merge 運用では特に誤解を招く。squash では feature ブランチのコミットが main の祖先にならないため `git branch -d` も `--merged` も効かず、「fetch -p しておけば片付く」と読むと、実際にはローカルにマージ済みブランチが溜まり続ける。実測で metaphor は 98 本中 52 本、metaphor-cli は 9 本中 6 本がこの状態だった。

claude-plugins [#67](https://github.com/shinyaoguri/claude-plugins/issues/67) → [#69](https://github.com/shinyaoguri/claude-plugins/pull/69) で env-doctor 側に `env-git-fetch-prune` / `env-git-gone-alias` が入り、掃除の手段は揃った。ただし `repo-standards.json` は正本が本リポジトリにあるため claude-plugins 側では直せず、**申し送りとして #69 のコメントに残っていた**。それを消化する。

## 変更点

`why` を実態に合わせ、正しい掃除手段を指すようにした。

> merge 後のブランチ掃除とセットの運用。git fetch -p が消すのは remote-tracking 参照だけなので、ローカルブランチは upstream:track == [gone] を手がかりに掃除する (env-doctor の env-git-fetch-prune / env-git-gone-alias)

`check` / `fix` / `level` は変更なし（GitHub 側の設定を要求すること自体は正しい）。

## 確認方法

- `python3 claude/tests/repo_standards_test.py` — 10 本 green（スキーマ整合・必須フィールド・参照解決）
- JSON としてパース可能なことを確認

関連: claude-plugins#67 / #69 / [#72](https://github.com/shinyaoguri/claude-plugins/issues/72)（worktree 掃除の fix にも同じ判定を使う提案）

🤖 Generated with [Claude Code](https://claude.com/claude-code)