### PR TITLE
feat(claude): 読み取り専用コマンドを allow に載せて確認プロンプトを減らす

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,12 @@ python3 claude/tests/runcat_metrics_test.py
 - スキルはこのリポでは配らない。自作の汎用スキルは shinyaoguri/claude-plugins (marketplace) の
   プラグインとして配布し、第三者配布スキルも含めて `claude/settings.json` の marketplace 宣言
   (`extraKnownMarketplaces` / `enabledPlugins`) で各マシンへ入れる
+- `settings.json` の `permissions.allow` に載せてよいのは**読み取り専用のコマンドだけ**。
+  allow は確認プロンプトを消す宣言なので、書き込み系を載せると「聞かれずに実行される」側へ倒れる。
+  サブコマンドまで固定して書く (`Bash(git log:*)` は可、`Bash(git:*)` は不可)。
+  判定は `claude/tests/settings_test.py` が CI で強制する — 引っかかったら足す前に考え直す。
+  プラグイン同梱スクリプトの実行許可はここでなく各スキルの `allowed-tools` frontmatter で宣言する
+  (`${CLAUDE_PLUGIN_ROOT}` が展開されるぶん、マシン依存の絶対パスを settings.json に書かずに済む)
 - `claude/repo-standards.json` はリポジトリ標準チェックリストの正本。消費者は
   shinyaoguri/claude-plugins の repo-standards プラグイン (`/repo-audit` 等が
   `~/.claude/repo-standards.json` 経由で読む)。項目の増減はテストが守るが、

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,7 +3,24 @@
     "TMPDIR": "/private/tmp"
   },
   "permissions": {
-    "allow": [],
+    "allow": [
+      "Bash(jq:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git diff:*)",
+      "Bash(git blame:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git worktree list:*)",
+      "Bash(gh auth status)",
+      "Bash(gh repo view:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)"
+    ],
     "additionalDirectories": []
   },
   "hooks": {

--- a/claude/tests/settings_test.py
+++ b/claude/tests/settings_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""claude/settings.json のテスト。
+
+settings.json は全マシンのグローバル設定の正本で、JSON が壊れると設定が丸ごと
+無視される (repo-standards の env-doctor が検知する事故そのもの)。ここでは
+パースの成立に加えて、`permissions.allow` が**読み取り専用の範囲を出ていない**
+ことを検証する。
+
+allow は確認プロンプトを消すための宣言なので、うっかり書き込み系を載せると
+「聞かれずに実行される」側へ倒れる。文書ルールで抑えるのでなく、変更を伴う
+コマンドが混ざった時点で CI が落ちるようにしておく。
+
+    python3 claude/tests/settings_test.py
+"""
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+SETTINGS = Path(__file__).resolve().parent.parent / "settings.json"
+
+# 状態を変える (取り消しに手間がかかる・外部へ influence が及ぶ) サブコマンドや
+# フラグの語。allow に載せてよいのは、これらを含まない読み取り専用の呼び出しだけ。
+# 新しい allow を足すときに引っかかったら、それは足す前に考え直す合図
+MUTATING_WORDS = {
+    # git: 履歴・作業ツリー・リモートを変える
+    "commit", "push", "merge", "rebase", "reset", "revert", "restore",
+    "checkout", "switch", "branch", "tag", "clean", "stash", "cherry-pick",
+    "apply", "mv", "gc", "prune", "remote", "submodule", "worktree",
+    # gh: GitHub 側を変える / 任意のメソッドを投げられる
+    "api", "create", "edit", "delete", "close", "reopen", "comment",
+    "upload", "sync", "clone", "fork", "ready", "review", "run", "rerun",
+    # 一般
+    "rm", "mkdir", "cp", "install", "publish", "deploy", "curl", "ssh",
+}
+
+# 上の語を含んでいても読み取りに閉じている例外。語単位の判定では拾えないので
+# ルール全体で照合する (git worktree list は一覧表示、gh pr diff は差分の表示)
+READ_ONLY_EXCEPTIONS = {
+    "git worktree list",
+    "gh pr diff",
+}
+
+RULE_RE = re.compile(r"^Bash\((?P<cmd>.+?)(?P<glob>:\*|\s\*)?\)$")
+
+
+class SettingsTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.raw = SETTINGS.read_text()
+        cls.data = json.loads(cls.raw)
+        cls.allow = cls.data.get("permissions", {}).get("allow", [])
+
+    def test_is_valid_json(self):
+        # setUpClass で落ちれば十分だが、失敗理由を「JSON が壊れている」と
+        # 名指しできるようにテストとしても残す
+        self.assertIsInstance(json.loads(self.raw), dict)
+
+    def test_allow_rules_are_bash_rules(self):
+        for rule in self.allow:
+            with self.subTest(rule=rule):
+                self.assertRegex(rule, RULE_RE, "allow は Bash(...) 形式で書く")
+
+    def test_allow_rules_are_not_blanket(self):
+        """コマンド名だけの包括ルール (Bash(git:*) など) を禁じる。
+
+        サブコマンドを問わず許すと、読み取りのつもりが push や delete まで
+        通ってしまう。許すのは必ずサブコマンドまで固定した形にする。
+        """
+        for rule in self.allow:
+            with self.subTest(rule=rule):
+                m = RULE_RE.match(rule)
+                self.assertIsNotNone(m, f"解析できないルール: {rule}")
+                cmd = m.group("cmd").strip()
+                self.assertNotEqual(cmd, "*", "全コマンドを許すルールは置かない")
+                if cmd in {"git", "gh", "npm", "docker", "kubectl"}:
+                    self.fail(f"サブコマンドを固定していない包括ルール: {rule}")
+
+    def test_allow_rules_are_read_only(self):
+        for rule in self.allow:
+            m = RULE_RE.match(rule)
+            cmd = m.group("cmd").strip() if m else rule
+            if cmd in READ_ONLY_EXCEPTIONS:
+                continue
+            hits = MUTATING_WORDS.intersection(cmd.split())
+            with self.subTest(rule=rule):
+                self.assertEqual(
+                    hits, set(),
+                    f"状態を変えうる語 {sorted(hits)} を含む allow は置かない "
+                    f"(確認プロンプトが消えるのは読み取り専用のコマンドだけ)",
+                )
+
+    def test_allow_rules_unique(self):
+        self.assertEqual(len(self.allow), len(set(self.allow)), "allow が重複している")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## 目的

`permissions.allow` が空のままで、調査・監査のたびに読み取りだけのコマンドまで
確認プロンプトが出ていた。repo-standards の監査は 1 巡でサブエージェントが
`git log` / `gh issue view` を多用するため、確認が何十回も挟まる。

読み取り専用に限った allowlist を置き、その線引きを CI で強制する。
shinyaoguri/claude-plugins#73 (プラグイン側の `allowed-tools` 宣言) と対になる変更。

## 変更点

### `claude/settings.json` — 読み取り専用コマンドの allowlist

状態を変えず外部にも影響しないコマンドだけを載せた (16 件)。

- git: `status` / `log` / `show` / `diff` / `blame` / `ls-files` / `rev-parse` / `worktree list`
- gh: `auth status` / `repo view` / `issue view` / `issue list` / `pr view` / `pr list` / `pr diff`
- `jq`

**載せなかったもの**と理由:

- `gh api` — メソッドを問わず投げられるので、読み取り用途でも対象外
- `git push` / `gh issue create` など書き込み・公開・削除を伴うもの
- `Bash(git:*)` のような包括ルール — 読み取りのつもりで push まで通してしまう
- プラグイン同梱スクリプト (`rs-*.sh`) の実行 — 各スキルの `allowed-tools`
  frontmatter で宣言する方が `${CLAUDE_PLUGIN_ROOT}` が展開されるぶん素直で、
  マシン依存の絶対パスを settings.json に持ち込まずに済む

### `claude/tests/settings_test.py` — 線引きを CI で強制する

allow は確認プロンプトを消す宣言なので、うっかり書き込み系を足すと「聞かれずに
実行される」側へ倒れる。文書ルールでなくテストで止める。

- settings.json が JSON として妥当か (壊れると設定が丸ごと無視される)
- allow が `Bash(...)` 形式か / 重複していないか
- サブコマンドを固定していない包括ルールが無いか
- 状態を変えうる語 (`push`・`create`・`api`・`rm` など) を含むルールが無いか

`git worktree list` と `gh pr diff` は語単位の判定では引っかかるが読み取りに
閉じているため、ルール全体を照合する例外として明示している。

### `CLAUDE.md` — 方針を 1 項目追記

## 確認方法

- `python3 -m unittest discover -s claude/tests -p '*_test.py'` → 127 tests OK
  (既存 122 + 新規 5)
- 新テストが実際に守れることを確認: `Bash(gh api:*)` / `Bash(git:*)` /
  `Bash(git push:*)` / `Bash(rm -rf:*)` を allow に混ぜると**それぞれ赤くなる**。
  取り除くと緑に戻る
- 作業は `~/.setup` の worktree で行ったので、ライブの `~/.claude/settings.json`
  (main checkout への symlink) は本 PR のマージまで変わらない。マージ後に
  `git -C ~/.setup pull` で反映される (新規ファイルは `claude/tests/` 配下のみで
  `claude_config_files` の追記は不要)
