### PR TITLE
feat(claude): 別 worktree への書き込みを止める PreToolUse フック

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -70,6 +70,17 @@
             "statusMessage": "プロビジョニングの変更内容を事前確認中"
           }
         ]
+      },
+      {
+        "matcher": "Edit|MultiEdit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/worktree-path-guard.sh",
+            "timeout": 10,
+            "statusMessage": "編集先の worktree を確認中"
+          }
+        ]
       }
     ]
   },

--- a/claude/tests/worktree_path_guard_test.py
+++ b/claude/tests/worktree_path_guard_test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""claude/worktree-path-guard.sh のテスト。
+
+フックの契約 (stdin の JSON → deny の JSON、あるいは無出力) をサブプロセス経由で
+検証する。判定はリポジトリの状態 (worktree の共通 .git) に依存するので、実際に
+git worktree を生やしたテスト用リポジトリを用意して走らせる。
+
+    python3 claude/tests/worktree_path_guard_test.py
+"""
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "worktree-path-guard.sh"
+
+
+class HookTestCase(unittest.TestCase):
+    def setUp(self):
+        self.workdir = tempfile.TemporaryDirectory()
+        root = Path(self.workdir.name)
+        self.addCleanup(self.workdir.cleanup)
+
+        # メイン作業ツリー + そこから生やした worktree（実運用と同じく、worktree は
+        # メインツリーの内側 .claude/worktrees/ に置く）
+        self.main = root / "repo"
+        self.main.mkdir()
+        self.git("init", "-q", "-b", "main", cwd=self.main)
+        self.git("config", "user.email", "t@example.com", cwd=self.main)
+        self.git("config", "user.name", "t", cwd=self.main)
+        (self.main / "app.swift").write_text("main\n")
+        self.git("add", "-A", cwd=self.main)
+        self.git("commit", "-qm", "init", cwd=self.main)
+
+        self.linked = self.main / ".claude" / "worktrees" / "wt"
+        self.git("worktree", "add", "-q", "-b", "feat", str(self.linked), cwd=self.main)
+
+        # まったく別のリポジトリ（別プロジェクトの編集は止めない）
+        self.other = root / "other"
+        self.other.mkdir()
+        self.git("init", "-q", cwd=self.other)
+        (self.other / "app.swift").write_text("other\n")
+
+    def git(self, *args, cwd):
+        subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+    def run_hook(self, cwd, tool="Edit", **tool_input):
+        return subprocess.run(
+            [str(SCRIPT)],
+            input=json.dumps(
+                {"tool_name": tool, "cwd": str(cwd), "tool_input": tool_input}
+            ),
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=30,
+        )
+
+    def assert_allowed(self, result):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "", "素通しのはずが出力があった")
+
+    def assert_denied(self, result):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        decision = payload["hookSpecificOutput"]["permissionDecision"]
+        self.assertEqual(decision, "deny", result.stdout)
+        return payload["hookSpecificOutput"]["permissionDecisionReason"]
+
+    # --- 素通しするもの ---------------------------------------------------
+
+    def test_same_worktree_is_allowed(self):
+        self.assert_allowed(
+            self.run_hook(self.linked, file_path=str(self.linked / "app.swift"))
+        )
+
+    def test_new_file_in_same_worktree_is_allowed(self):
+        self.assert_allowed(
+            self.run_hook(self.linked, file_path=str(self.linked / "new" / "x.swift"))
+        )
+
+    def test_other_repository_is_allowed(self):
+        # 別プロジェクトを触るのは正当な作業なので止めない
+        self.assert_allowed(
+            self.run_hook(self.linked, file_path=str(self.other / "app.swift"))
+        )
+
+    def test_outside_any_repository_is_allowed(self):
+        with tempfile.TemporaryDirectory() as plain:
+            self.assert_allowed(
+                self.run_hook(self.linked, file_path=str(Path(plain) / "note.md"))
+            )
+
+    def test_missing_file_path_is_allowed(self):
+        self.assert_allowed(self.run_hook(self.linked, tool="Bash", command="ls"))
+
+    def test_session_outside_repository_is_allowed(self):
+        with tempfile.TemporaryDirectory() as plain:
+            self.assert_allowed(
+                self.run_hook(plain, file_path=str(self.main / "app.swift"))
+            )
+
+    # --- 止めるもの -------------------------------------------------------
+
+    def test_main_worktree_from_linked_worktree_is_denied(self):
+        # 実際に起きた事故そのもの: worktree セッションでメインツリーの絶対パスを掴む
+        reason = self.assert_denied(
+            self.run_hook(self.linked, file_path=str(self.main / "app.swift"))
+        )
+        self.assertIn(str(self.linked / "app.swift"), reason, "訂正後のパスが無い")
+
+    def test_linked_worktree_from_main_is_denied(self):
+        # 逆向き（並行して走っている別セッションの作業ツリーを踏む）も止める
+        reason = self.assert_denied(
+            self.run_hook(self.main, file_path=str(self.linked / "app.swift"))
+        )
+        self.assertIn(str(self.main / "app.swift"), reason)
+
+    def test_nested_path_keeps_its_relative_position(self):
+        nested = self.main / "Sources" / "Deep" / "File.swift"
+        nested.parent.mkdir(parents=True)
+        nested.write_text("x\n")
+        reason = self.assert_denied(self.run_hook(self.linked, file_path=str(nested)))
+        self.assertIn(str(self.linked / "Sources" / "Deep" / "File.swift"), reason)
+
+    def test_new_file_in_other_worktree_is_denied(self):
+        # 実在しないパスでも（親ディレクトリから）どの worktree かは決まる
+        reason = self.assert_denied(
+            self.run_hook(self.linked, file_path=str(self.main / "brand-new.swift"))
+        )
+        self.assertIn(str(self.linked / "brand-new.swift"), reason)
+
+    def test_notebook_edit_is_denied(self):
+        self.assert_denied(
+            self.run_hook(
+                self.linked, tool="NotebookEdit", notebook_path=str(self.main / "n.ipynb")
+            )
+        )
+
+    def test_falls_back_to_process_cwd(self):
+        # cwd がペイロードに無い版のホストでも効く
+        result = subprocess.run(
+            [str(SCRIPT)],
+            input=json.dumps(
+                {"tool_name": "Edit", "tool_input": {"file_path": str(self.main / "app.swift")}}
+            ),
+            capture_output=True,
+            text=True,
+            cwd=str(self.linked),
+            timeout=30,
+        )
+        self.assert_denied(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/claude/worktree-path-guard.sh
+++ b/claude/worktree-path-guard.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Claude Code の PreToolUse フック: いま居る worktree の外 (= 同じリポジトリの別 worktree)
+# へ書き込む事故を水際で止める。
+#
+# worktree セッション中に、メイン作業ツリーの絶対パスで Read → Edit してしまい、変更が
+# ブランチではなくメインツリーへ落ちた事故があった。Edit の「事前に Read が必要」という
+# ガードは、同じ (間違った) ファイルを読んでいれば通ってしまうので、取り違えは検知できない。
+# パスは自己申告で、しかも両ツリーに同名のファイルが存在するため、間違いが目に見えない。
+#
+# 「編集先はいまのセッションの worktree の中」はリポジトリの状態から機械的に決まるので、
+# 文書ルールではなくここで決定論的に落とす。
+#
+# 判定は「同じリポジトリの別 worktree か」だけを見る:
+#   - 同じ worktree の中          → 素通し
+#   - 別のリポジトリ (submodule 含む) → 素通し (正当な作業。ここで止める理由がない)
+#   - 同じリポジトリの別 worktree  → deny (訂正後のパスを添えて返す)
+#
+# ask ではなく deny なのは、取り違えなら正しいパスへ直せばその場で続行できるから
+# (人を呼ぶ必要がない)。本当に別ツリーを触りたいときは、そのツリーで作業している
+# セッションから行う — 並行セッションが同じファイルを取り合う状況こそ避けたい。
+#
+# 契約: stdin に PreToolUse の JSON。素通しは無出力 + 終了コード 0。
+# 呼び出し口は settings.json の hooks.PreToolUse、テストは
+# claude/tests/worktree_path_guard_test.py (python3 で直接実行)。
+
+set -uo pipefail
+
+deny() { # $1=理由
+  jq -n --arg r "$1" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
+  exit 0
+}
+
+payload=$(cat)
+
+# Edit/Write は file_path、NotebookEdit は notebook_path。書き込み先を持たない
+# ツール (Bash など) は素通し
+target=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' 2>/dev/null) || exit 0
+[ -n "$target" ] || exit 0
+
+cwd=$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null)
+[ -n "$cwd" ] || cwd=$PWD
+
+# 実在する最も近い親ディレクトリの物理パス (新規ファイルの作成にも効かせるため、
+# ファイル自身の実在は前提にしない)
+resolve_dir() {
+  local dir=$1 parent
+  while [ ! -d "$dir" ]; do
+    parent=$(dirname "$dir")
+    [ "$parent" = "$dir" ] && return 1
+    dir=$parent
+  done
+  (cd "$dir" 2>/dev/null && pwd -P)
+}
+
+# 相対パスはセッションの cwd 基準 (Claude Code は絶対パスを要求するが、念のため)
+case $target in
+  /*) ;;
+  *) target=$cwd/$target ;;
+esac
+
+target_dir=$(resolve_dir "$(dirname "$target")") || exit 0
+cwd_dir=$(resolve_dir "$cwd") || exit 0
+
+# git 管理外はここで終わり (~/.claude のメモリ、スクラッチパッド等)
+target_root=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null) || exit 0
+current_root=$(git -C "$cwd_dir" rev-parse --show-toplevel 2>/dev/null) || exit 0
+target_root=$(resolve_dir "$target_root") || exit 0
+current_root=$(resolve_dir "$current_root") || exit 0
+
+[ "$target_root" = "$current_root" ] && exit 0
+
+# worktree は共通の .git ディレクトリを指す。ここが一致するときだけ「同じリポジトリの
+# 別 worktree」= 取り違え。別リポジトリ (submodule やまったく別のプロジェクト) は素通し
+common_of() {
+  git -C "$1" rev-parse --path-format=absolute --git-common-dir 2>/dev/null
+}
+target_common=$(common_of "$target_dir")
+current_common=$(common_of "$cwd_dir")
+[ -n "$target_common" ] && [ -n "$current_common" ] || exit 0
+target_common=$(resolve_dir "$target_common") || exit 0
+current_common=$(resolve_dir "$current_common") || exit 0
+[ "$target_common" = "$current_common" ] || exit 0
+
+# 訂正後のパスを添える。取り違えの実体は「同じ相対パスを別のツリーに向けた」なので、
+# ツリーの根だけ差し替えれば意図した先になる
+relative=${target_dir#"$target_root"/}
+[ "$relative" = "$target_dir" ] && relative=""  # 対象がツリー直下
+suggested=$current_root${relative:+/$relative}/$(basename "$target")
+
+note="（訂正先はまだ存在しません。新規作成ならこのままで問題ありません）"
+[ -e "$suggested" ] && note="（訂正先は存在します）"
+
+deny "$(cat <<EOF
+同じリポジトリの**別 worktree** へ書き込もうとしています。パスの取り違えです。
+
+  このセッションの worktree : $current_root
+  書き込もうとした worktree : $target_root
+
+このまま書くと、変更はいまのブランチではなく別のツリーへ落ちます (同名のファイルが
+両方にあるため、差分を見るまで気付けません)。
+
+訂正後のパス:
+  $suggested
+$note
+
+本当に別の worktree を変更する必要があるなら、そのツリーで作業しているセッションから
+行ってください。
+EOF
+)"

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -22,8 +22,9 @@
 #
 # git-signing-preflight.sh は 1Password の承認待ちでコミット署名が落ちるのを防ぎ、
 # git-safety-guard.sh は取り返しのつかない git 操作と秘密ファイルのコミットを止める
-# PreToolUse フック。呼び出し口はどちらも settings.json の hooks、テストは
-# claude/tests/*_test.py (python3 で直接実行)
+# PreToolUse フック。worktree-path-guard.sh は同じリポジトリの別 worktree への書き込み
+# (パスの取り違え) を止める PreToolUse フック。呼び出し口はいずれも settings.json の
+# hooks、テストは claude/tests/*_test.py (python3 で直接実行)
 #
 # repo-standards.json はリポジトリ標準チェックリストの正本。消費者は claude-plugins の
 # repo-standards プラグイン (~/.claude/repo-standards.json 経由で読む)。
@@ -38,6 +39,7 @@
       - git-signing-preflight.sh
       - git-safety-guard.sh
       - provisioning-preflight.sh
+      - worktree-path-guard.sh
 
 - name: Create ~/.claude directory
   ansible.builtin.file:


### PR DESCRIPTION
## 背景（実際に起きた事故）

`shinyaoguri/metaphor` の worktree セッションで作業中、example を編集するのに **メイン作業ツリーの絶対パス**（`/Users/so/Repos/metaphor/Examples/…`）で `Read` → `Edit` してしまい、変更がブランチではなくメインツリーに落ちました。

- `Edit` の「事前に `Read` が必要」というガードは、**同じ間違ったファイルを読んでいれば通る**ので取り違えを検知できない
- 両ツリーに**同名のファイルが存在する**ため、編集自体は成功し、`git status` を見るまで間違いが目に見えない
- 同じ原因で `gh pr create` も「head branch main is the same as base branch main」で 1 回失敗した（メインツリーは main チェックアウト中）

「編集先はいまのセッションの worktree の中」はリポジトリの状態から機械的に決まります。文書ルールにせず、決定論的に落とす場所へ移しました。

## 判定

共通 `.git` ディレクトリ（`git rev-parse --git-common-dir`）の一致だけで「同じリポジトリの別 worktree か」を見ます。

| 書き込み先 | 判定 |
| --- | --- |
| 同じ worktree の中 | 素通し |
| git 管理外（`~/.claude` のメモリ、スクラッチパッド） | 素通し |
| 別のリポジトリ（submodule・別プロジェクト） | 素通し |
| **同じリポジトリの別 worktree** | **deny**（訂正後のパスを添える） |

`ask` ではなく `deny` にしたのは、取り違えなら正しいパスへ直せばその場で続行できるからです（人を呼ばずに自己修正できる。バッチで走るセッションを止めない）。逆向き — メインツリーのセッションから `.claude/worktrees/` 配下を触る — も止めます。並行セッションの作業ツリーを踏む事故は同じ形なので。

実際の事故を再現した出力:

```
同じリポジトリの**別 worktree** へ書き込もうとしています。パスの取り違えです。

  このセッションの worktree : /Users/so/Repos/metaphor/.claude/worktrees/vigilant-solomon-946a81
  書き込もうとした worktree : /Users/so/Repos/metaphor

このまま書くと、変更はいまのブランチではなく別のツリーへ落ちます (同名のファイルが
両方にあるため、差分を見るまで気付けません)。

訂正後のパス:
  /Users/so/Repos/metaphor/.claude/worktrees/vigilant-solomon-946a81/Examples/…/App.swift
（訂正先は存在します）
```

## 変更点

- `claude/worktree-path-guard.sh` — フック本体（`Edit` / `MultiEdit` / `Write` / `NotebookEdit` の `file_path` / `notebook_path` を見る）
- `claude/settings.json` — `hooks.PreToolUse` に matcher `Edit|MultiEdit|Write|NotebookEdit` で登録
- `tasks/claude.yml` — `claude_config_files` に追加（`~/.claude/` への symlink 対象）
- `claude/tests/worktree_path_guard_test.py` — テスト 12 本

## 確認方法

- `python3 claude/tests/worktree_path_guard_test.py` → 12 tests OK。実際に `git worktree add` した一時リポジトリで、素通し 6 種（同一 worktree / 新規ファイル / 別リポジトリ / git 管理外 / 書き込み先なし / セッションが git 外）と deny 6 種（両方向・入れ子パス・新規ファイル・NotebookEdit・`cwd` 不在時の `$PWD` フォールバック）を固定
- テストが実装を守っていることを、フックを 3 通りに壊して確認:

  | 変異 | 赤くなったテスト |
  | --- | --- |
  | 同一リポ判定を外す | `test_other_repository_is_allowed` |
  | 同一 worktree の素通しを外す | `test_same_worktree_is_allowed` / `test_new_file_in_same_worktree_is_allowed` |
  | 訂正パスの相対位置を捨てる | `test_nested_path_keeps_its_relative_position` |

- `python3 -m unittest discover -s claude/tests -p '*_test.py'` → 139 tests OK
- 実環境（この Mac の metaphor worktree）でも誤検知がないことを確認: 自分の worktree 内 / メモリ / スクラッチパッド / `~/.setup` は素通し、並行セッションの worktree は deny

## 適用

`~/.claude/worktree-path-guard.sh` の symlink は手元では作成済み（この PR がマージされたら `ansible-playbook` の通常適用で追随します）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)