### PR TITLE
fix(claude): マージ済みブランチの掃除で毎回確認を求めてしまう穴を塞ぐ

### DIFF
--- a/claude/git-safety-guard.sh
+++ b/claude/git-safety-guard.sh
@@ -61,18 +61,10 @@ has() { printf '%s' "$scan" | grep -qE "$1"; }
 # いずれも「可逆と確認できたときだけ真」。リポジトリの外・判定材料が足りないときは
 # 偽を返し、呼び出し側で ask に落とす。
 
-# `git branch -D` の対象がすべて「追跡先が消えたブランチ」か。
-#
-# squash merge では feature ブランチのコミットが main の祖先にならないため
-# `--merged` では判定できない。代わりに upstream の消失 ([gone]) を役目終了の
-# 代理指標に使う (グローバル CLAUDE.md のブランチ掃除運用と同じ判定)。内容は main に
-# 入っており、元コミットも GitHub 側に refs/pull/<N>/head として残るため可逆。
+# `git branch -D` の対象がすべて「役目を終えたブランチ」か。
 branch_delete_targets_are_gone() {
-  local targets target track
-  targets=$(printf '%s' "$command" | awk '{
-    for (i = 1; i <= NF; i++)
-      if ($i == "-D") { for (j = i + 1; j <= NF; j++) print $j; exit }
-  }')
+  local targets target
+  targets=$(branch_delete_targets)
   [ -n "$targets" ] || return 1
 
   for target in $targets; do
@@ -80,10 +72,42 @@ branch_delete_targets_are_gone() {
     case "$target" in
       -*|*'$'*|*'"'*|*"'"*|*'`'*) return 1 ;;
     esac
-    track=$(git for-each-ref --format='%(upstream:track)' "refs/heads/$target" 2>/dev/null)
-    [ "$track" = "[gone]" ] || return 1
+    branch_is_spent "$target" || return 1
   done
   return 0
+}
+
+# `-D` に続くブランチ名を取り出す。シェルの区切り・リダイレクトが現れたら打ち切る。
+# `git branch -D x 2>&1 | tail -1` の "2>&1" までブランチ名として読むと、実在しない
+# 名前として判定不能に落ち、掃除のたびにユーザーを呼ぶことになる。
+branch_delete_targets() {
+  printf '%s' "$command" | awk '{
+    for (i = 1; i <= NF; i++)
+      if ($i == "-D") {
+        for (j = i + 1; j <= NF; j++) {
+          if ($j ~ /[;&|<>]/) exit
+          print $j
+        }
+        exit
+      }
+  }'
+}
+
+# そのブランチを消しても失うものが無いと確認できるか。
+#
+# squash merge では feature ブランチのコミットが main の祖先にならないため
+# `--merged` では判定できない。代わりに upstream の消失 ([gone]) を役目終了の
+# 代理指標に使う (グローバル CLAUDE.md のブランチ掃除運用と同じ判定)。内容は main に
+# 入っており、元コミットも GitHub 側に refs/pull/<N>/head として残るため可逆。
+#
+# 「内容が既定ブランチに入っているか」は指標にしない。squash merge 直後の掃除も
+# 通せて魅力的だが、それだけでは*まだ作業中の*ブランチ (main に無い変更をまだ
+# 持っていないだけ) と区別できず、生きた PR のブランチまで黙って消せてしまう。
+# マージ直後に消したいときは先に `git fetch -p` を通す — [gone] になってここを抜ける。
+branch_is_spent() {
+  local track
+  track=$(git for-each-ref --format='%(upstream:track)' "refs/heads/$1" 2>/dev/null)
+  [ "$track" = "[gone]" ]
 }
 
 # エイリアス経由の `git branch -D` が「gone なブランチだけ」を対象にすると確認できるか。
@@ -127,7 +151,7 @@ has "${GIT}restore([[:space:]]|$)" && ! has '\-\-staged' &&
   danger="git restore は作業ツリーの変更を復元できない形で捨てる"
 has "${GIT}branch${ARG}-D([[:space:]]|$)" &&
   ! branch_delete_targets_are_gone && ! alias_deletes_only_gone_branches &&
-  danger="git branch -D はマージ済みかを問わずブランチを消す"
+  danger="git branch -D はマージ済みかを問わずブランチを消す (マージ後の掃除なら先に git fetch -p を通す。追跡先が畳まれれば確認なしで通る)"
 has "${GIT}push${ARG}(--force|-f([[:space:]]|$))" &&
   danger="force push は remote の履歴を書き換える (他の作業や PR に影響する)"
 has "${GIT}stash${ARG}(drop|clear)" &&

--- a/claude/tests/git_safety_guard_test.py
+++ b/claude/tests/git_safety_guard_test.py
@@ -194,6 +194,65 @@ class ReversibleOperationTest(HookTestCase):
         self.with_remote()
         self.assert_decision(self.run_hook("git branch -D feature/nope"), "ask")
 
+    def test_redirection_after_the_branch_name_is_not_a_target(self):
+        """`git branch -D x 2>&1 | tail -1` の後続はブランチ名ではない。
+
+        リダイレクトやパイプまで対象として読むと、実在しない名前の判定不能で
+        ask に落ち、掃除のたびにユーザーを呼ぶことになる。
+        """
+        self.with_remote()
+        self.make_gone_branch("feature/done")
+        self.assert_allowed(self.run_hook("git branch -D feature/done 2>&1 | tail -1"))
+
+    def test_squash_merged_branch_asks_until_pruned(self):
+        """squash merge 済みでも、リモート追跡が生きている間は ask のまま。
+
+        「内容が main に入っているか」だけでは、まだ作業中のブランチ (main に無い
+        変更をまだ持っていないだけ) と区別できない。掃除は `git fetch -p` を通して
+        [gone] にしてから — それで確認なしに抜けられる。
+        """
+        self.with_remote()
+        subprocess.run(
+            ["git", "checkout", "-q", "-b", "feature/squashed"], cwd=self.repo, check=True
+        )
+        (self.repo / "f.txt").write_text("done\n")
+        subprocess.run(["git", "add", "f.txt"], cwd=self.repo, check=True)
+        self.commit("work")
+        subprocess.run(
+            ["git", "push", "-q", "-u", "origin", "feature/squashed"],
+            cwd=self.repo, check=True,
+        )
+        # main へ squash 相当で取り込む (fetch -p はまだしない)
+        subprocess.run(["git", "checkout", "-q", "main"], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "merge", "-q", "--squash", "feature/squashed"], cwd=self.repo, check=True
+        )
+        self.commit("squashed work")
+        subprocess.run(["git", "push", "-q", "origin", "main"], cwd=self.repo, check=True)
+        self.assert_decision(self.run_hook("git branch -D feature/squashed"), "ask")
+
+        # マージ後にリモート側が畳まれ、fetch -p が届けば確認は要らなくなる
+        subprocess.run(
+            ["git", "-C", str(self.origin), "update-ref", "-d", "refs/heads/feature/squashed"],
+            check=True,
+        )
+        subprocess.run(["git", "fetch", "-pq"], cwd=self.repo, check=True)
+        self.assert_allowed(self.run_hook("git branch -D feature/squashed"))
+
+    def test_ask_reason_points_at_fetch_prune(self):
+        """確認を求めるときは、確認なしで通す道 (fetch -p) を示す。"""
+        self.with_remote()
+        subprocess.run(
+            ["git", "checkout", "-q", "-b", "feature/wip"], cwd=self.repo, check=True
+        )
+        self.commit("wip")
+        subprocess.run(
+            ["git", "push", "-q", "-u", "origin", "feature/wip"], cwd=self.repo, check=True
+        )
+        subprocess.run(["git", "checkout", "-q", "-"], cwd=self.repo, check=True)
+        reason = self.assert_decision(self.run_hook("git branch -D feature/wip"), "ask")
+        self.assertIn("fetch -p", reason)
+
     # --- エイリアス経由 ---------------------------------------------------
 
     def test_gone_clean_alias_passes(self):


### PR DESCRIPTION

## 目的

git-safety-guard は「その場で可逆と確認できたものまで止めない」方針だが、
実運用のブランチ掃除がほぼ毎回 ask に落ちていた。

原因は `-D` の後ろを最後までブランチ名として読んでいたこと。
`git branch -D feature/x 2>&1 | tail -1` のようにリダイレクトやパイプが続くと、
`2>&1` まで対象名として扱われ、実在しない名前 = 判定不能 → 安全側の ask に
落ちる。可逆性の判定そのものは正しかったのに、入力の切り出しで潰れていた。

## 変更点

- `-D` に続く語からブランチ名を切り出すとき、シェルの区切り・リダイレクト
  （`;` `&` `|` `<` `>` を含む語）が現れたら打ち切る
- 可逆性の判定を `branch_is_spent()` として切り出し、判断の理由をコメントに残す
- ask の理由に「マージ後の掃除なら先に `git fetch -p` を通す」を添える
  （追跡先が畳まれれば [gone] になり、確認なしで通る道を示す）

## 見送ったこと

「内容が既定ブランチに入っているか」（squash merge 直後、fetch -p 前でも
通せる）は入れなかった。それだけでは**まだ作業中の**ブランチ（main に無い
変更をまだ持っていないだけ）と区別できず、生きた PR のブランチを黙って
消せてしまうため。テストで ask のままであることを固定した。

## 確認方法

`claude/tests/git_safety_guard_test.py` に 3 件追加（34 tests OK）:

- リダイレクトが続いても [gone] なブランチは素通し（修正前は ask）
- squash merge 済みでも追跡先が生きている間は ask、`fetch -p` 後は素通し
- ask の理由が `fetch -p` を示す

打ち切り行を外すと 1 件目が赤くなることを確認。実リポ（metaphor）でも
[gone] なブランチがリダイレクト付きコマンドで allow、upstream の無い
ローカル専用ブランチは ask のままであることを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)