### PR TITLE
feat(claude): push 前で内容が main にあるブランチも確認なしで消せるようにする

### DIFF
--- a/claude/git-safety-guard.sh
+++ b/claude/git-safety-guard.sh
@@ -100,21 +100,54 @@ branch_delete_targets() {
   }'
 }
 
-# そのブランチを消しても失うものが無いと確認できるか。
+# そのブランチを消しても失うものが無いと確認できるか。指標は upstream の有無で分かれる。
 #
-# squash merge では feature ブランチのコミットが main の祖先にならないため
-# `--merged` では判定できない。代わりに upstream の消失 ([gone]) を役目終了の
-# 代理指標に使う (グローバル CLAUDE.md のブランチ掃除運用と同じ判定)。内容は main に
-# 入っており、元コミットも GitHub 側に refs/pull/<N>/head として残るため可逆。
+# (a) upstream があった → その消失 ([gone]) を役目終了の代理指標にする。squash merge では
+#     feature ブランチのコミットが main の祖先にならないため `--merged` では判定できない
+#     (グローバル CLAUDE.md のブランチ掃除運用と同じ判定)。内容は main に入っており、
+#     元コミットも GitHub 側に refs/pull/<N>/head として残るため可逆。
 #
-# 「内容が既定ブランチに入っているか」は指標にしない。squash merge 直後の掃除も
-# 通せて魅力的だが、それだけでは*まだ作業中の*ブランチ (main に無い変更をまだ
-# 持っていないだけ) と区別できず、生きた PR のブランチまで黙って消せてしまう。
-# マージ直後に消したいときは先に `git fetch -p` を通す — [gone] になってここを抜ける。
+# (b) upstream が無い (= まだ push していない手元だけの枝) → tip が既定ブランチの
+#     リモート追跡に含まれるかを見る。含まれていればコミットは remote から取り戻せる。
+#
+# upstream を持つブランチに (b) を当ててはいけない。「内容が既定ブランチに入っている」だけ
+# では*まだ作業中の*ブランチ (main に無い変更をまだ持っていないだけ) と区別できず、生きた
+# PR のブランチまで黙って消せてしまう。マージ直後に消したいときは先に `git fetch -p` を
+# 通す — [gone] になって (a) を抜ける。
+#
+# (b) でも「作ったばかりで、まだコミットが無いブランチ」は同じ形に見える。それを消しても
+# 失うのはブランチ名だけ (git switch -c で作り直せる) なので、確認を挟むほどではないと
+# 判断した — worktree セッションが残す push 前のブランチが溜まる実態のほうが重い。
 branch_is_spent() {
   local track
   track=$(git for-each-ref --format='%(upstream:track)' "refs/heads/$1" 2>/dev/null)
-  [ "$track" = "[gone]" ]
+  [ "$track" = "[gone]" ] && return 0
+  branch_is_local_only_and_contained "$1"
+}
+
+# 既定ブランチのリモート追跡参照。origin/HEAD が無いリポでも動くよう名前でも探す。
+default_remote_branch() {
+  local ref
+  ref=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)
+  if [ -z "$ref" ]; then
+    for ref in origin/main origin/master; do
+      git rev-parse --verify --quiet "$ref" >/dev/null 2>&1 && break
+      ref=""
+    done
+  fi
+  [ -n "$ref" ] || return 1
+  printf '%s' "$ref"
+}
+
+# push していないブランチで、tip が既定ブランチのリモート追跡に含まれているか。
+branch_is_local_only_and_contained() {
+  local upstream tip default_ref
+  upstream=$(git for-each-ref --format='%(upstream)' "refs/heads/$1" 2>/dev/null)
+  [ -z "$upstream" ] || return 1
+  tip=$(git rev-parse --verify --quiet "refs/heads/$1") || return 1
+  [ -n "$tip" ] || return 1
+  default_ref=$(default_remote_branch) || return 1
+  git merge-base --is-ancestor "$tip" "$default_ref" 2>/dev/null
 }
 
 # エイリアス経由の `git branch -D` が「gone なブランチだけ」を対象にすると確認できるか。
@@ -189,7 +222,8 @@ is_reversible_branch_cleanup() {
   # -d は git 自身がマージ済みかを確かめ、未マージなら断る (失うものが無い)
   printf '%s' "$trimmed" | grep -qE '^git[[:space:]]+branch[[:space:]]+-d([[:space:]]|$)' &&
     return 0
-  # -D は追跡先が畳まれている (= 内容は既定ブランチ側にある) と確認できたときだけ
+  # -D は対象すべてが「消しても失うものが無い」と確認できたときだけ
+  # (追跡先が畳まれている / push 前で内容が既定ブランチに入っている)
   printf '%s' "$trimmed" | grep -qE '^git[[:space:]]+branch[[:space:]]+-D([[:space:]]|$)' &&
     branch_delete_targets_are_gone && return 0
   # `git gone-clean` のような、掃除エイリアス 1 本きりの呼び出し
@@ -200,7 +234,7 @@ is_reversible_branch_cleanup() {
 }
 
 if is_reversible_branch_cleanup; then
-  decide allow "消えて困るものが無いと確認できたブランチ削除 (-d は git がマージ済みかを確かめて未マージなら断る / -D と掃除エイリアスは追跡先が [gone] のブランチだけを対象にしており、内容は既定ブランチと GitHub の refs/pull に残る)。確認は不要。"
+  decide allow "消えて困るものが無いと確認できたブランチ削除 (-d は git がマージ済みかを確かめて未マージなら断る / -D と掃除エイリアスの対象は追跡先が [gone] か、push 前で内容が既定ブランチに入っているブランチだけで、コミットは remote から取り戻せる)。確認は不要。"
 fi
 
 # --- 3. 秘密情報らしきファイルのコミット -----------------------------------

--- a/claude/tests/git_safety_guard_test.py
+++ b/claude/tests/git_safety_guard_test.py
@@ -203,20 +203,65 @@ class ReversibleOperationTest(HookTestCase):
         subprocess.run(["git", "checkout", "-q", "-"], cwd=self.repo, check=True)
         self.assert_decision(self.run_hook("git branch -D feature/wip"), "ask")
 
-    def test_deleting_a_local_only_branch_asks(self):
-        """upstream を持たない (push していない) ブランチは、消すと復元できない。"""
+    def test_deleting_a_contained_local_only_branch_is_auto_approved(self):
+        """push 前でも、tip が origin/main にあるならコミットは remote から取り戻せる。
+
+        worktree セッションが残す push 前のブランチはこの形で溜まる (upstream を
+        持たないので [gone] にはなりえない)。
+        """
         self.with_remote()
         subprocess.run(["git", "branch", "feature/local"], cwd=self.repo, check=True)
-        self.assert_decision(self.run_hook("git branch -D feature/local"), "ask")
+        self.assert_auto_approved(self.run_hook("git branch -D feature/local"))
+
+    def test_deleting_a_local_only_branch_with_own_commits_asks(self):
+        """push もしておらず origin/main にも無いコミットは、消すと本当に失われる。"""
+        self.with_remote()
+        subprocess.run(
+            ["git", "checkout", "-q", "-b", "feature/unpushed"], cwd=self.repo, check=True
+        )
+        self.commit("only here")
+        subprocess.run(["git", "checkout", "-q", "-"], cwd=self.repo, check=True)
+        self.assert_decision(self.run_hook("git branch -D feature/unpushed"), "ask")
 
     def test_mixed_targets_ask(self):
         """1 つでも確認できない対象が混ざれば、全体を ask にする。"""
         self.with_remote()
         self.make_gone_branch("feature/done")
-        subprocess.run(["git", "branch", "feature/local"], cwd=self.repo, check=True)
-        self.assert_decision(
-            self.run_hook("git branch -D feature/done feature/local"), "ask"
+        subprocess.run(
+            ["git", "checkout", "-q", "-b", "feature/unpushed"], cwd=self.repo, check=True
         )
+        self.commit("only here")
+        subprocess.run(["git", "checkout", "-q", "-"], cwd=self.repo, check=True)
+        self.assert_decision(
+            self.run_hook("git branch -D feature/done feature/unpushed"), "ask"
+        )
+
+    def test_live_branch_without_own_commits_asks(self):
+        """push 済みのブランチは、内容が origin/main に入っていても ask のまま。
+
+        「内容が既定ブランチにある」は push 前のブランチにしか当てない指標。
+        push 済み = 共有済みで、まだ差分が無いだけの*作業中*のブランチと区別が
+        つかないため、これを当てると生きた PR のブランチまで黙って消せてしまう。
+        """
+        self.with_remote()
+        subprocess.run(
+            ["git", "checkout", "-q", "-b", "feature/fresh"], cwd=self.repo, check=True
+        )
+        subprocess.run(
+            ["git", "push", "-q", "-u", "origin", "feature/fresh"],
+            cwd=self.repo, check=True,
+        )
+        subprocess.run(["git", "checkout", "-q", "-"], cwd=self.repo, check=True)
+        self.assert_decision(self.run_hook("git branch -D feature/fresh"), "ask")
+
+    def test_local_only_branch_without_remote_asks(self):
+        """リモートを持たないリポジトリでは、取り戻せる先が無い。"""
+        subprocess.run(
+            ["git", "commit", "-q", "--allow-empty", "-m", "init"],
+            cwd=self.repo, check=True,
+        )
+        subprocess.run(["git", "branch", "feature/local"], cwd=self.repo, check=True)
+        self.assert_decision(self.run_hook("git branch -D feature/local"), "ask")
 
     def test_unknown_branch_asks(self):
         self.with_remote()


### PR DESCRIPTION
## 目的

前回 ([#65](https://github.com/shinyaoguri/setup/pull/65)) で可逆と確認できたブランチ掃除は `allow` で通るようにしたが、可逆判定の指標が upstream の消失 (`[gone]`) だけだったため、**一度 push したブランチにしか効かなかった**。

worktree セッションが切る `claude/*` の多くは push されないまま終わるので upstream を持たず、`[gone]` 判定の土俵に乗らない。metaphor での実測:

```
push 未 (upstream 無し)   54 本  ← 永久に [gone] にならない。うち 53 本は tip が origin/main に含まれる
[gone] (掃除可)           14 本
追跡が生きている            4 本
```

53 本は消してもコミットを 1 つも失わないのに、`-D` のたびに確認を求めていた。

## 変更点

可逆性の指標を upstream の有無で分けた。

| 対象 | 指標 |
|---|---|
| upstream があった | 従来どおり `[gone]` (squash merge 済み、内容は main と `refs/pull` に残る) |
| upstream が無い | tip が既定ブランチのリモート追跡の祖先か (コミットは remote から取り戻せる) |

**upstream を持つブランチに後者を当てないことが肝**。「内容が既定ブランチにある」だけでは、まだ差分が無いだけの*作業中*のブランチと区別できず、生きた PR のブランチまで黙って消せてしまう。origin を持たないリポジトリも、取り戻せる先が無いので ask のまま。

なお push 前でも「作ったばかりでコミットが無いブランチ」は同じ形に見える。消しても失うのはブランチ名だけ (`git switch -c` で作り直せる) なので、確認を挟むほどではないと判断した — 掃除のたびに人を呼ぶ実態のほうが重い。

## 確認方法

```
python3 -m unittest discover -s claude/tests -p '*_test.py'   # 147 tests OK
```

テストが効いていることも確認済み:

- 新しい指標を潰す → `test_deleting_a_contained_local_only_branch_is_auto_approved` が赤
- upstream ガードを外す → `test_live_branch_without_own_commits_asks` が赤 (この観点はレビュー中に穴が見つかって追加した)

🤖 Generated with [Claude Code](https://claude.com/claude-code)