### PR TITLE
feat(git): 取り込み済みローカルブランチ用に stale / stale-clean エイリアスを足す

### DIFF
--- a/tasks/git.yml
+++ b/tasks/git.yml
@@ -37,6 +37,22 @@
 #
 # 削除するのはローカルの参照だけで、内容は main に入っており、元コミットも
 # GitHub 側に refs/pull/<N>/head として残るため情報は失われない。
+#
+# ただし [gone] 判定は **upstream を持つブランチしか拾えない**。一度も push して
+# いないローカル専用ブランチ（Claude Code の worktree 分離が作る worktree-agent-*
+# や、push せずに終わったセッションブランチ）は upstream が無いので永遠に対象外で、
+# これが実際に数十本まで積み上がった。
+#
+# そこで判定をもう 1 本用意する。「既定ブランチの祖先である」= 内容が完全に
+# 取り込み済みで、消しても 1 ビットも失われないローカルブランチ:
+#
+#   git stale         # 既定ブランチに取り込み済みのローカルブランチを一覧
+#   git stale-clean   # それを削除（-d のみ。取り込み済みでなければ git が拒否する）
+#
+# 除外は for-each-ref に任せる: %(worktreepath) が非空 = どこかの worktree が
+# 掴んでいる（現在のブランチを含む）ので候補から外れ、既定ブランチ自身も名前で
+# 外す。fetch はしない — 祖先判定は単調で、origin/main が古くても誤爆せず
+# 「拾い漏らす」側にしか倒れないため、オフラインでも安全に走る。
 
 - name: Prune stale remote-tracking branches on every fetch
   community.general.git_config:
@@ -54,6 +70,18 @@
   community.general.git_config:
     name: alias.gone-clean
     value: "!git gone | while read -r branch; do git branch -D \"$branch\"; done"
+    scope: global
+
+- name: Add git alias `stale` (list local branches already contained in the default branch)
+  community.general.git_config:
+    name: alias.stale
+    value: '!base=$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main); git for-each-ref --format="%(refname:short) %(worktreepath)" refs/heads | awk "NF==1 {print \$1}" | grep -vxF "${base#origin/}" | while read -r branch; do git merge-base --is-ancestor "$branch" "$base" 2>/dev/null && echo "$branch"; done; true'
+    scope: global
+
+- name: Add git alias `stale-clean` (delete the branches listed by `git stale`)
+  community.general.git_config:
+    name: alias.stale-clean
+    value: '!git stale | while read -r branch; do git branch -d "$branch"; done'
     scope: global
 
 - name: Read SSH public key from 1Password agent


### PR DESCRIPTION
## 目的

既存の `git gone` は役目終了を `upstream:track == [gone]` で判定するため、**一度も push していないローカル専用ブランチを永遠に拾えません**。Claude Code の worktree 分離が作る `worktree-agent-*` や、push せずに終わったセッションブランチがこれに当たります。

`shinyaoguri/metaphor` で 77 本まで積み上がっていました。設定自体（`fetch.prune=true` / `gone` エイリアス / リポ側 `delete_branch_on_merge=true`）は正しく入っており、**判定の対象が半分しかなかった**のが原因です。

| 分類 | 本数 | `git gone` で拾えるか |
|---|---|---|
| `origin/main` の祖先（大半が `worktree-agent-*`。未 push） | 56 | ❌ |
| squash マージ済み PR のブランチ | 18 | ✅ |
| worktree 使用中 / remote 残存 | 3 | — |

## 変更点

`[gone]` とは別のシグナル =「既定ブランチ（`origin/HEAD`、無ければ `origin/main`）の祖先である」= 内容が完全に取り込み済みで消しても 1 ビットも失われないもの、を判定する 2 本を追加します。

```bash
git stale         # 取り込み済みのローカルブランチを一覧
git stale-clean   # それを削除（-d のみ。取り込み済みでなければ git が拒否する）
```

- 除外は `for-each-ref` の `%(worktreepath)` に任せる（非空 = どこかの worktree が掴んでいる。現在のブランチを含む）。既定ブランチ自身は名前で外す
- **fetch はしない** — 祖先判定は単調なので remote-tracking が古くても誤爆せず「拾い漏らす」側にしか倒れません。オフラインでも安全に走ります
- 削除は `-d` のみ（`gone-clean` の `-D` と違い、取り込み済みでなければ git 自身が拒否する）

同じ判定で自動削除する SessionStart hook を repo-standards 側に入れました（shinyaoguri/claude-plugins#96）。このエイリアスは手動棚卸し用で、hook はエイリアスに依存せず単体で動きます。

## 確認方法

実リポ（metaphor）で `git config --global` に入れて検証:

- 取り込み済みブランチのみ削除される
- 未マージブランチ・worktree が掴んでいるブランチ・既定ブランチは残る
- 掃除対象ゼロでも `exit 0`（`git stale-clean` を素の状態で叩ける）

yml に書いてある値は、その検証済みの `git config --global` の実物をそのまま写したものです（`--tags git` 再実行で差分が出ないことを担保）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)