### PR TITLE
chore(claude): コミットと PR の Claude 帰属表示を止める

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -2,6 +2,11 @@
   "env": {
     "TMPDIR": "/private/tmp"
   },
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "permissions": {
     "allow": [
       "Bash(jq:*)",


### PR DESCRIPTION
## 目的

GitHub のコミット画面で共同作者として Claude が並ぶのを止め、コミットの帰属を本人だけにする。

## 事実確認 (metaphor リポで調査)

- **author / committer が Claude になっていたことは一度も無い**。`git log --all` の author は本人 (3 アドレス) / dependabot / github-actions のみで、committer は squash merge の `GitHub <noreply@github.com>` か本人。GitHub の contributors API も `shinyaoguri` / `dependabot[bot]` / `github-actions[bot]` の 3 者のみ
- 表示の出どころは**コミット本文の trailer**。main の履歴に `Co-authored-by: Claude ...` が計 300 件超、`🤖 Generated with [Claude Code]` が 58 件。GitHub はこの trailer を解釈して共同作者アイコンを並べるため、コミッターに Claude がいるように見えていた
- ワークツリー・サブエージェントは無関係 (trailer は全セッションに一律で付いていた。`user.name` / `user.email` の上書きも無し)

## 変更点

`claude/settings.json` に `attribution` を追加し、Claude Code が自動で付けていた 3 種の帰属表示を消す。

| フィールド | 消えるもの |
| --- | --- |
| `commit: ""` | コミットの `Co-Authored-By: Claude <モデル名> <noreply@anthropic.com>` trailer |
| `pr: ""` | PR 本文の `🤖 Generated with [Claude Code]` 行 |
| `sessionUrl: false` | web / Remote Control セッション由来の `Claude-Session` trailer |

`includeCoAuthoredBy` は settings スキーマ上 deprecated (`attribution` に置き換え) なので使わない。

## 確認方法

- `jq -e '.attribution' claude/settings.json` が 3 フィールドを返し、JSON 全体も妥当
- symlink 経由 (`~/.claude/settings.json`) でも同じ値が読める
- **本 PR のコミット自体が実証**: author / committer とも `Shinya Oguri <ogrsny@gmail.com>` で、本文に trailer が無い

## 残すもの

既存コミットの trailer は履歴書き換え (force push) を伴うためそのまま残す。contributors には現れていないので実害は無い。