### PR TITLE
chore(claude): Claude の関与を trailer に残しつつ GitHub の共同作者表示から外す

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,7 +3,7 @@
     "TMPDIR": "/private/tmp"
   },
   "attribution": {
-    "commit": "",
+    "commit": "Assisted-by: Claude <noreply@anthropic.com>",
     "pr": "",
     "sessionUrl": false
   },


### PR DESCRIPTION
## 目的

#69 では帰属表示を丸ごと消したが、**Claude が関与した記録自体は残したい**。GitHub のコミット画面に共同作者として並ばないことだけが目的なので、trailer のキー名を変えて両立させる。

## 実測

GitHub は `Co-authored-by` trailer **のみ**を共同作者としてパースする。使い捨てブランチに空コミット 5 本を push し、GraphQL の `Commit.authors`（GitHub のパース結果そのもの）と Web UI の両方で確認した。

| trailer の書き方 | 共同作者表示 |
| --- | --- |
| `Co-authored-by: Claude Opus 5 <noreply@anthropic.com>` | **出る**（「shinyaoguri and claude committed」+ アバター 2 つ） |
| `Assisted-by: Claude Opus 5 <noreply@anthropic.com>` | **出ない**（本文に行は残る） |
| `Co-authored-by: Claude Opus 5`（メール省略） | **出ない** |
| `Co-authored-by: Claude Opus 5 <未紐づけメール>` | **出る**（アカウント無しでも名前が並ぶ） |
| trailer ブロックの外に置く | **出ない** |

分かったこと:

- **決定要因はキー名**。キー名だけを変えた 1 と 2 で結果が反転する
- 大文字小文字は無関係（`Co-Authored-By` も `Co-authored-by` も同じくパースされる）
- `noreply@anthropic.com` は**実在の `claude` アカウントに紐づいている**（GraphQL が `login: claude` を返す）。これがリンク付きで並んでいた正体
- メールアドレスを未紐づけのものに変えても消えない（名前だけ並ぶ）

## 変更点

`attribution.commit` に `Assisted-by: Claude <noreply@anthropic.com>` を設定。

- メール省略でも消せるが、trailer として不完全な形になる。構文を保てる**別キー名**を採った（`git interpret-trailers` などのツールも正しく扱える）
- **モデル名は入れない**。カスタム文字列へモデル名を差し込むプレースホルダは公式に文書化されておらず、固定値だとモデル交代で陳腐化する
- PR 本文の帰属（`pr`）は共同作者パースと無関係なので空のまま据え置き

## 確認方法

- `jq -e '.attribution' claude/settings.json` が 3 フィールドを返し、JSON 全体も妥当。symlink 経由（`~/.claude/settings.json`）でも同じ値
- 実測に使ったブランチは削除済み（記録は上の表と本文に残す）
- 次のセッション以降のコミットで `Assisted-by:` 行が付き、GitHub 上は「shinyaoguri committed」のみになることを確認する