### PR TITLE
feat(claude): 同じ承認を毎回押さずに済むよう権限の範囲を宣言する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ python3 claude/tests/runcat_metrics_test.py
   判定は `claude/tests/settings_test.py` が CI で強制する — 引っかかったら足す前に考え直す。
   プラグイン同梱スクリプトの実行許可はここでなく各スキルの `allowed-tools` frontmatter で宣言する
   (`${CLAUDE_PLUGIN_ROOT}` が展開されるぶん、マシン依存の絶対パスを settings.json に書かずに済む)
+- `permissions.additionalDirectories` は「毎回同じ承認を押している場所」だけを足す。ここは
+  コマンドでなく**範囲**の宣言で、読み取りが無確認になるだけ (編集の可否は permission mode に
+  従うので default モードでは確認が残る)。worktree セッションはリポ本体も設定の実体も範囲外に
+  なるため、`~/Repos` / `~/.setup` / `~/.claude` を常設している。パスは `~/` 始まりで書く
+  (展開は効く。絶対パスだとユーザー名がマシンに依存する)。範囲の広すぎと書き方は
+  `claude/tests/settings_test.py` が CI で見る
 - 書き込み系のコマンドを確認なしで通したいときは allow ではなく PreToolUse フック側で判定する。
   allow は文字列の前方一致でしかなく「安全な場合だけ」を表現できないが、フックはリポジトリの
   状態を見て可逆と確認できたときだけ `allow` を返せる (`claude/git-safety-guard.sh` の

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -24,9 +24,14 @@
       "Bash(gh issue list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
-      "Bash(gh pr diff:*)"
+      "Bash(gh pr diff:*)",
+      "Bash(op read:*)"
     ],
-    "additionalDirectories": []
+    "additionalDirectories": [
+      "~/Repos",
+      "~/.setup",
+      "~/.claude"
+    ]
   },
   "hooks": {
     "PostToolUse": [

--- a/claude/tests/settings_test.py
+++ b/claude/tests/settings_test.py
@@ -95,5 +95,53 @@ class SettingsTestCase(unittest.TestCase):
         self.assertEqual(len(self.allow), len(set(self.allow)), "allow が重複している")
 
 
+class AdditionalDirectoriesTestCase(unittest.TestCase):
+    """`permissions.additionalDirectories` のテスト。
+
+    ここに書いたディレクトリは全マシンで確認なしに読める範囲になる (編集の可否は
+    permission mode に従うので、default モードなら書き込みの確認は残る)。緩めるのは
+    「毎回同じ承認を押している場所」だけに留めたいので、範囲の広すぎとマシン依存の
+    書き方を CI で落とす。
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        data = json.loads(SETTINGS.read_text())
+        cls.dirs = data.get("permissions", {}).get("additionalDirectories", [])
+
+    def test_paths_are_home_relative(self):
+        """`~/` 始まりで書く (ユーザー名を埋め込むとマシンを移ったとき効かなくなる)。
+
+        `~` が展開されることは実測済み: 範囲外の空ディレクトリから `claude -p` を
+        走らせると、`~/Repos` を渡したときだけ範囲外のファイルを読めた。
+        """
+        for path in self.dirs:
+            with self.subTest(path=path):
+                self.assertTrue(
+                    path.startswith("~/"),
+                    "additionalDirectories は ~/ 始まりで書く "
+                    "(絶対パスはユーザー名がマシンに依存する)",
+                )
+
+    def test_paths_are_not_too_broad(self):
+        """ホーム直下や / をまるごと開けない。
+
+        個別のディレクトリを足すのは範囲の追加だが、ホームそのものを足すのは
+        「全部入り」への切り替えで意味が違う。
+        """
+        for path in self.dirs:
+            with self.subTest(path=path):
+                self.assertNotIn(
+                    path.rstrip("/"), {"~", "/", ""},
+                    "ホーム全体・ルート全体を開ける指定は置かない",
+                )
+
+    def test_paths_unique(self):
+        self.assertEqual(
+            len(self.dirs), len(set(self.dirs)),
+            "additionalDirectories が重複している",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## 目的

毎セッション、Mac のファイルアクセスと 1Password で同じ承認を押し続けていた。原因を切り分けたところ、片方は消せる種類のもので、もう片方は消すべきでないものだった。

**ファイルアクセス**: 承認の記憶は cwd 単位で `~/.claude.json` の `projects[<cwd>]` に入る。ところが worktree セッションでは cwd が `.claude/worktrees/<使い捨て名>` になるので、毎回まっさらな別プロジェクト扱いになる。実際に数えると worktree 由来のエントリ 63 個すべてで `allowedTools` が空だった。さらに設定の実体 (`~/.setup`) もリポ本体も worktree からは範囲外で、CLAUDE.md やフックを読むだけで範囲外アクセスが発生する。セッションを跨いで残るのは設定ファイル側の宣言だけなので、そちらで恒久化する。

**1Password**: 2 層で聞かれていた。Claude 側の Bash 確認は重複なので消す。1Password 本体の生体認証と SSH agent の確認は鍵の使用そのものなので残す (`~/.config/op/config` は `accounts: null` = デスクトップアプリ統合で、頻度はアプリの自動ロック設定側の話)。

macOS の TCC は無関係だった。`~/Documents` と `~/Desktop` は現に読めており、OS のダイアログは承認済み。

## 変更点

- `claude/settings.json`
  - `permissions.additionalDirectories` に `~/Repos` / `~/.setup` / `~/.claude` を常設
  - `permissions.allow` に `Bash(op read:*)` を追加 (読み出しのみ。`op:*` にはしない)
- `claude/tests/settings_test.py` — `additionalDirectories` の書き方を CI で強制する `AdditionalDirectoriesTestCase` を追加 (`~/` 始まり・ホーム/ルート全体の禁止・重複禁止)
- `CLAUDE.md` — allow との違い (コマンドではなく範囲の宣言・緩むのは読み取りだけ) を「非自明なところ」に追記

## 範囲がどこまで広がるか

`additionalDirectories` が無確認にするのは**読み取りだけ**で、編集の可否は permission mode に従う。default モードなら書き込みの確認は今までどおり残る。既存の「allow に載せてよいのは読み取り専用のコマンドだけ」という線引きと同じ側に収まっている。

## 確認方法

- `python3 -m unittest discover -s claude/tests -p '*_test.py'` → 150 tests OK
- 新しいテストは、`additionalDirectories` を絶対パス・`~`・重複ありに一時的に書き換えて 3 本とも赤くなることを確認してから仕上げた
- `~` が展開されることの実測: 範囲外の空ディレクトリから `claude -p` で範囲外のファイルを読ませると、`--settings '{"permissions":{"additionalDirectories":["~/Repos"]}}'` を渡したときは中身が返り、渡さないと `DENIED` になった