### PR TITLE
feat(claude): 着手中の Issue を GitHub 側から見えるようにする

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -27,6 +27,7 @@
 
 - コードの識別子は英語。コメント・ドキュメント・コミット要約は日本語でよい
 - GitHub Flow: main が唯一の長命ブランチ。作業は main から `<type>/<短い説明>` ブランチを切り、小さく作って早めに PR (WIP なら Draft)
+- **着手した Issue には `status: in progress` を付け、PR が merge されたら / 中断したら外す** (ラベルが無いリポでは `gh label create` で作る)。複数のセッションが同じリポで並行するので、着手は push を待たずに GitHub 側から見える必要がある。次のタスクを選ぶときはこのラベルが付いた Issue と、in-flight PR が触っているファイル群を避ける — 収集から着手までの手順は repo-standards プラグインの next-task スキルが持つ
 - コミットは Conventional Commits: `<type>(<scope>): <要約>`。type は feat / fix / docs / refactor / test / chore / ci。1 コミット 1 関心
 - Squash merge 前提。PR タイトルもコミットと同形式に書く (マージコミットのメッセージになる)
 - コミットログと PR 本文 (目的・変更点・確認方法) を丁寧に書くこと。それが書けていて CI が green なら、push / merge は指示を待たず進めてよい (force push・main への直接 push は上記の不可逆操作として事前確認)


### PR DESCRIPTION
## 目的

複数の Claude セッションが同じリポジトリで並行するのに、**着手中の作業を示す印が GitHub 側に無かった**。open issue の assignee 使用は 0 件、`status: in progress` 相当のラベルも未定義で、着手は PR を push するまで外から見えない。結果として「次のタスクに着手して」と指示したときに、他セッションが掘っている Issue を掴む余地が残っていた。

排他印を GitHub に置けば、セッションの記憶がリセットされても正本は残る。

## 変更点

`claude/CLAUDE.md`「ソフトウェア開発」節に 1 項目追加:

- 着手した Issue には `status: in progress` を付け、PR が merge されたら / 中断したら外す (ラベルが無いリポでは `gh label create` で作る)
- 次のタスクを選ぶときは、このラベルが付いた Issue と in-flight PR が触っているファイル群を避ける

収集から着手までの**手順**はここには書かず、repo-standards プラグインの `next-task` スキルが持つ (shinyaoguri/claude-plugins 側で別 PR)。この規約は「何を印にするか」だけを定める。

## 確認方法

- `python3 -m unittest discover -s claude/tests -p '*_test.py'` → 190 tests OK
- 記述のみの変更で、フック・スクリプトの挙動は変わらない