### PR TITLE
fix(claude): プランの記録が黙って作られなくなっていたのを直す

### DIFF
--- a/claude/plan-record.sh
+++ b/claude/plan-record.sh
@@ -23,12 +23,23 @@
 #   sanitize  stdin の本文からパス類を落として stdout へ (テストと手動確認用)
 #   scan      stdin の本文から BLOCK / WARN 行を stdout へ (テストと手動確認用)
 #
+# 環境変数: CLAUDE_PLAN_RECORD=0 で無効化 / CLAUDE_PLAN_RECORD_DEBUG=1 で
+# 何もせず終わった理由を stderr へ出す (黙って効かなくなったときの切り分け用)。
+#
 # 呼び出し口は settings.json の hooks、テストは claude/tests/plan_record_test.py。
 
 set -uo pipefail
 
+# 何もせず終わる経路の理由を見せる。既定は無言 (フックは全リポで動くので、
+# 通常運転で喋ると邪魔になる)。仕組みが黙って効かなくなったときの切り分け用で、
+# CLAUDE_PLAN_RECORD_DEBUG=1 を付けて同じ payload を流し直せば理由が出る
+debug() { [ "${CLAUDE_PLAN_RECORD_DEBUG:-0}" = "0" ] || printf 'plan-record: %s\n' "$1" >&2; }
+
 # 一時的に止めたいときの逃げ道 (このフックは全リポで動くため)
-[ "${CLAUDE_PLAN_RECORD:-1}" = "0" ] && exit 0
+if [ "${CLAUDE_PLAN_RECORD:-1}" = "0" ]; then
+  debug 'CLAUDE_PLAN_RECORD=0 で無効化されている'
+  exit 0
+fi
 
 MAX_NAGS=3      # guard が差し戻す回数の上限。超えたら諦めて人間の判断へ返す
 STALE_DAYS=14   # 投稿先が現れないまま放置された記録を捨てるまでの日数
@@ -163,24 +174,77 @@ record_dir() {
   printf '%s/claude-plan-records' "$common"
 }
 
+# --- プラン本文の取り出し ---------------------------------------------------
+# 本文の置き場は Claude Code のバージョンで動く:
+#   以前 — モデルが ExitPlanMode の引数として本文を渡していた (.tool_input.plan)
+#   現在 — モデルは引数を取らず本文はファイルに書かれる。フックへは
+#          .tool_response.plan / .tool_response.filePath として返り、
+#          .tool_input は {"_targetMode":"auto"} だけになる
+# 1 箇所に賭けるとこの変化で黙って壊れる (Issue #87 がそれ) ので、ありうる場所を
+# 順に見て最初に見つかった本文を使い、本文が直接来ていなければファイルから読む。
+
+plan_body() { # $1=payload → プラン本文 (見つからなければ空)
+  local payload="$1" body file
+  body=$(printf '%s' "$payload" | jq -r '
+    first((
+      .tool_input.plan?, .tool_input.content?, .tool_input.text?, .tool_response.plan?
+    ) | select(type == "string" and . != ""))' 2>/dev/null)
+  if [ -z "$body" ]; then
+    file=$(printf '%s' "$payload" | jq -r '
+      first((
+        .tool_response.filePath?, .tool_response.planFilePath?, .tool_input.planFilePath?
+      ) | select(type == "string" and . != ""))' 2>/dev/null)
+    [ -n "$file" ] && [ -f "$file" ] && body=$(cat "$file")
+  fi
+  printf '%s' "$body"
+}
+
+payload_keys() { # $1=payload $2=キー名 → そのオブジェクトのキー一覧
+  # 値は出さない。プランにも tool_response にも秘密情報が混ざりうるので、
+  # 次に直す人の手がかりになるキー名だけを見せる
+  printf '%s' "$1" | jq -r --arg k "$2" '
+    .[$k] | if type == "object" then (keys | join(",")) else "(\(type))" end' 2>/dev/null ||
+    printf '(不明)'
+}
+
 # --- capture ----------------------------------------------------------------
 
 capture() {
   local payload plan cwd session root branch dir id file body findings blocks warns target
 
   payload=$(cat)
-  command -v jq >/dev/null 2>&1 || exit 0
+  if ! command -v jq >/dev/null 2>&1; then
+    debug 'jq が無い'
+    exit 0
+  fi
 
-  plan=$(printf '%s' "$payload" | jq -r '.tool_input | (.plan // .content // .text // "")' 2>/dev/null)
-  [ -n "$plan" ] || exit 0
+  plan=$(plan_body "$payload")
+  if [ -z "$plan" ]; then
+    # ExitPlanMode が通った以上プランは必ず存在するので、本文が取れないこと自体が異常。
+    # ここだけは黙って諦めない — 無言で終わると guard も黙り、「プランを GitHub に
+    # 残す」仕組みが誰にも気付かれないまま無効化される (それが Issue #87)
+    cat >&2 <<EOF
+ExitPlanMode は通りましたが、プラン本文を取り出せませんでした。GitHub 用の記録は作れていません。
+
+プランは ~/.claude/plans/ に残っているので、PR / Issue のコメントへ手で投稿してください。
+そのうえで、フックが受け取る形が変わっていないか claude/plan-record.sh の plan_body() を確かめてください。
+
+  受け取ったキー: tool_input=$(payload_keys "$payload" tool_input) / tool_response=$(payload_keys "$payload" tool_response)
+EOF
+    exit 2
+  fi
+
   cwd=$(printf '%s' "$payload" | jq -r '.cwd // ""')
   session=$(printf '%s' "$payload" | jq -r '.session_id // "nosession"')
   [ -n "$cwd" ] && cd "$cwd" 2>/dev/null
 
   # git リポジトリの外で立てたプランには投稿先が無い。黙って通す
-  root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
-  dir=$(record_dir) || exit 0
+  if ! root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    debug "git リポジトリの外 (cwd=$cwd)"
+    exit 0
+  fi
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || { debug 'HEAD を解決できない'; exit 0; }
+  dir=$(record_dir) || { debug 'record_dir を解決できない'; exit 0; }
 
   body=$(printf '%s' "$plan" | sanitize "$root" "$(logical_root "$cwd")")
   findings=$(printf '%s' "$body" | scan)
@@ -200,7 +264,7 @@ EOF
     exit 2
   fi
 
-  mkdir -p "$dir" 2>/dev/null || exit 0
+  mkdir -p "$dir" 2>/dev/null || { debug "記録の置き場を作れない ($dir)"; exit 0; }
   id="${session%%-*}-$(date +%s)"
   file="$dir/$id.md"
 
@@ -257,16 +321,16 @@ guard() {
   local payload cwd dir branch meta id file nags target kind number pending='' round=0
 
   payload=$(cat)
-  command -v jq >/dev/null 2>&1 || exit 0
-  command -v gh >/dev/null 2>&1 || exit 0
+  command -v jq >/dev/null 2>&1 || { debug 'jq が無い'; exit 0; }
+  command -v gh >/dev/null 2>&1 || { debug 'gh が無い'; exit 0; }
 
   cwd=$(printf '%s' "$payload" | jq -r '.cwd // ""')
-  [ -n "$cwd" ] || exit 0
-  cd "$cwd" 2>/dev/null || exit 0
-  dir=$(record_dir) || exit 0
-  [ -d "$dir" ] || exit 0
+  [ -n "$cwd" ] || { debug 'payload に cwd が無い'; exit 0; }
+  cd "$cwd" 2>/dev/null || { debug "cwd へ移動できない ($cwd)"; exit 0; }
+  dir=$(record_dir) || { debug 'git リポジトリの外'; exit 0; }
+  [ -d "$dir" ] || { debug "未投稿の記録が無い ($dir)"; exit 0; }
 
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || { debug 'HEAD を解決できない'; exit 0; }
 
   for meta in "$dir"/*.meta; do
     [ -f "$meta" ] || continue

--- a/claude/tests/plan_record_test.py
+++ b/claude/tests/plan_record_test.py
@@ -87,6 +87,21 @@ class PlanRecordTestCase(unittest.TestCase):
             **env,
         )
 
+    def capture_payload(self, **overrides):
+        """tool_input / tool_response を差し替えて capture を叩く。
+
+        プラン本文の置き場は Claude Code のバージョンで動くので、素の payload を
+        組めるようにしておく (self.capture は旧来の tool_input.plan 形式の近道)。
+        """
+        env = {k: v for k, v in overrides.items() if k.isupper()}
+        payload = {
+            "tool_name": "ExitPlanMode",
+            "cwd": str(self.repo),
+            "session_id": "abcd1234-ef56-7890",
+            **{k: v for k, v in overrides.items() if not k.isupper()},
+        }
+        return self.run_hook("capture", payload, **env)
+
     def guard(self, **env):
         return self.run_hook("guard", {"cwd": str(self.repo)}, **env)
 
@@ -209,6 +224,76 @@ class PlanRecordTestCase(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stderr, "")
+
+    # --- プラン本文の取り出し (置き場は Claude Code のバージョンで動く) --------
+
+    def test_capture_reads_the_plan_from_the_tool_response(self):
+        # 現行の ExitPlanMode はモデルが引数を取らず、本文は tool_response に返る。
+        # tool_input だけを見ていたころは、ここで無言のまま記録が作られなかった
+        result = self.capture_payload(
+            tool_input={"_targetMode": "auto"},
+            tool_response={"plan": "## 方針\n\n却下案: 全面書き換え。\n", "isAgent": False},
+            FAKE_GH_PR="42",
+        )
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertEqual(len(self.records()), 1)
+        self.assertIn("却下案: 全面書き換え", self.records()[0].read_text())
+
+    def test_capture_reads_the_plan_from_the_file_it_was_written_to(self):
+        plan_file = Path(self.workdir.name) / "plan.md"
+        plan_file.write_text("## 方針\n\nファイル越しに渡されたプラン。\n")
+        result = self.capture_payload(
+            tool_input={"_targetMode": "auto"},
+            tool_response={"filePath": str(plan_file)},
+            FAKE_GH_PR="42",
+        )
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("ファイル越しに渡されたプラン", self.records()[0].read_text())
+
+    def test_capture_speaks_up_when_the_plan_cannot_be_found(self):
+        # ExitPlanMode が通った以上プランは必ずある。取り出せないなら異常なので、
+        # 黙って諦めると guard も黙り、仕組みごと無言で無効化される (Issue #87)
+        result = self.capture_payload(
+            tool_input={"_targetMode": "auto"}, tool_response={}, FAKE_GH_PR="42"
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(self.records(), [])
+        self.assertIn("取り出せませんでした", result.stderr)
+        # 次に直す人のために、受け取ったキーだけを見せる (値は出さない)
+        self.assertIn("_targetMode", result.stderr)
+
+    # --- 何もせず終わった理由の可視化 -----------------------------------------
+
+    def test_debug_explains_why_nothing_happened(self):
+        outside = Path(self.workdir.name) / "plain"
+        outside.mkdir()
+        result = subprocess.run(
+            [str(SCRIPT), "capture"],
+            input=json.dumps(
+                {"cwd": str(outside), "session_id": "x", "tool_input": {"plan": "計画"}}
+            ),
+            capture_output=True, text=True, cwd=str(outside),
+            env=self.env(CLAUDE_PLAN_RECORD_DEBUG="1"), timeout=30,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("plan-record:", result.stderr)
+        self.assertIn("git リポジトリの外", result.stderr)
+
+    def test_debug_is_off_by_default(self):
+        # 通常運転では黙っていること (全リポで動くフックなので喋ると邪魔になる)
+        result = self.capture_payload(
+            tool_input={"plan": "計画。\n"}, CLAUDE_PLAN_RECORD="0"
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+
+    def test_debug_explains_being_disabled(self):
+        result = self.capture_payload(
+            tool_input={"plan": "計画。\n"},
+            CLAUDE_PLAN_RECORD="0", CLAUDE_PLAN_RECORD_DEBUG="1",
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("無効化されている", result.stderr)
 
     # --- guard --------------------------------------------------------------
 


### PR DESCRIPTION
Closes #87

## 目的

`ExitPlanMode` の PostToolUse に登録した `capture` が、承認まで通ったセッションで**記録を作らず**、Stop の `guard` も黙って、「プランを GitHub に残す」仕組みが無言で無効化されていた。

## 原因

**プラン本文の置き場が変わっていた。** 現行の Claude Code の `ExitPlanMode` はモデルが引数を取らず、本文はファイルに書かれる。フックへ実際に渡る payload をダンプして確認した:

```json
"tool_input":    {"_targetMode": "auto"},
"tool_response": {"plan": "# …", "filePath": "~/.claude/plans/….md", "isAgent": false}
```

`capture` は `.tool_input | (.plan // .content // .text // "")` だけを見ていたため、**「プランが空」として静かに `exit 0`** していた。記録が作られないので `guard` も何も言わず、誰も気付けない。

`.md` は `resolve_target` (ネットワーク) より前に書かれるので、タイムアウトで殺されてもファイルは残るはず — にもかかわらず**ディレクトリごと存在しなかった**ことから `mkdir` より手前の経路に絞り込み、cwd が git 内・jq あり・BLOCK 無しを確認して「`plan` が空」まで追い込んだうえで、ダンプで裏を取った。

## 変更点

### `plan_body()` を足して、ありうる置き場を順に見る

`tool_input.plan` → `.content` → `.text` → `tool_response.plan` の順で本文を探し、直接来ていなければ `tool_response.filePath` / `planFilePath` からファイルを読む。1 箇所に賭けると同じ変化でまた黙って壊れるため、順に見る形にした。

### 本文が取れないときは無言で諦めない

`ExitPlanMode` が通った以上プランは必ず存在するので、**取り出せないこと自体が異常**。ここだけ `exit 0` をやめ `exit 2` で差し戻し、「手で投稿してほしい」と伝える。次に直す人の手がかりとして**受け取ったキー名だけ**を添える (値は出さない — プランにも `tool_response` にも秘密情報が混ざりうるため)。

git の外・jq 無しは今までどおり無言で通す (投稿先が無いのは正常な状態)。

### `CLAUDE_PLAN_RECORD_DEBUG=1` で無言終了の理由を出す

jq 無し / git 外 / 置き場を作れない / `CLAUDE_PLAN_RECORD=0` で無効化、の各経路で理由を 1 行 stderr へ。`guard` 側の無言終了も同じ扱いにした。既定は無言のまま (全リポで動くフックなので通常運転で喋らせない)。

## 確認方法

`claude/tests/plan_record_test.py` を 17 → **23 tests** へ拡張。追加したのは:

- `tool_response.plan` から記録を作る ← **今回の回帰**
- `tool_response.filePath` のファイルから記録を作る
- 本文がどこにも無ければ `exit 2` で差し戻し、受け取ったキー名を見せる
- `CLAUDE_PLAN_RECORD_DEBUG=1` で理由が出る / 無効化の理由も出る
- **既定では今までどおり無言** (静けさを壊していないことの対照)

**新テストが効いていることの確認**: `plan-record.sh` だけを修正前に戻すと 5 件が赤くなる。

```
FAIL: test_capture_reads_the_plan_from_the_tool_response
FAIL: test_capture_reads_the_plan_from_the_file_it_was_written_to
FAIL: test_capture_speaks_up_when_the_plan_cannot_be_found
FAIL: test_debug_explains_why_nothing_happened
FAIL: test_debug_explains_being_disabled
```

残る 1 件 (`test_debug_is_off_by_default`) は両方で緑が正しい — 既定の静けさを守る対照テスト。

**実物の payload での確認**: ダンプした本物の payload (`tool_input` が `_targetMode` だけのもの) を使い捨てリポで `capture` へ流すと、記録が作られ投稿手順が出る。

全体: `python3 -m unittest discover -s claude/tests -p '*_test.py'` → **196 tests OK**。

マージ後に `~/.setup` を pull して、実際に `EnterPlanMode` → `ExitPlanMode` を通し、記録が作られることをライブで確認します。

---
<sub>🤖 Assisted by [Claude Code](https://claude.com/claude-code)</sub>
