### PR TITLE
chore(zshrc): grok CLI の PATH と補完をリポジトリ側へ取り込む

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -122,3 +122,9 @@ export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agen
 if command -v direnv >/dev/null 2>&1; then
   eval "$(direnv hook zsh)"
 fi
+
+# >>> grok installer >>>
+export PATH="$HOME/.grok/bin:$PATH"
+fpath=(~/.grok/completions/zsh $fpath)
+autoload -Uz compinit && compinit -C
+# <<< grok installer <<<


### PR DESCRIPTION
## 目的

grok CLI のインストーラが `~/.zshrc` の実体 (このリポジトリの `zshrc`) を直接書き換えていた。`~/.zshrc` は `tasks/zshrc.yml` が張る symlink なので、**リポジトリ側へ取り込まないと次に checkout した時点で消える**うえ、他のマシンにも配布されない。

実際 #91 の調査中に、実機の `~/.setup` に未コミットの差分として残っているのを発見した (あわせてインストーラが作った `zshrc.bak.1786720569` も残っていたので、`HEAD` の `zshrc` と同一であることを確認したうえで削除した)。

## 変更点

- `zshrc` — 末尾に grok の PATH と補完設定 (インストーラが書いた 5 行) を取り込む

## 確認方法

```bash
zsh -lc 'command -v grok'
```

`~/.grok/bin/grok` が引けること。

---
<sub>🤖 Assisted by [Claude Code](https://claude.com/claude-code)</sub>
