### PR TITLE
fix(zshenv): SSH_AUTH_SOCK を zshenv へ移し、無人セッションでも agent を引けるようにする

### DIFF
--- a/claude/tests/zshenv_test.py
+++ b/claude/tests/zshenv_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""zshenv のテスト。
+
+zshenv は「人が打つとき以外にも要るもの」の置き場。zshrc は非対話シェル
+(Claude Code の hook・scheduled task・cron) では読まれないので、そこへ置いたものは
+無人セッションでだけ黙って消える。GYAZO_TOKEN_REF で一度踏み (#90)、SSH_AUTH_SOCK で
+同じ轍を踏んだ (#91) ため、両方ここで固定する。
+
+肝は SSH_AUTH_SOCK の分岐で、次の 2 つを対にして見る:
+  - ローカルのシェルでは Secretive (Secure Enclave) の agent を指すこと
+  - SSH 越しに入っているときは触らないこと (forwarding された agent を壊さない)
+
+    python3 claude/tests/zshenv_test.py
+"""
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+ZSHENV = REPO / "zshenv"
+SECRETIVE_SOCK = "com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+
+
+def source_zshenv(**overrides):
+    """zshenv を非対話 zsh で source し、見たい変数を取り出す。
+
+    値に None を渡した変数は環境から落とす (未設定の再現)。
+    """
+    env = {k: v for k, v in os.environ.items()}
+    for key, value in overrides.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+    result = subprocess.run(
+        ["zsh", "-c", f'source "{ZSHENV}"; printf "%s\\n%s\\n%s\\n" "$SSH_AUTH_SOCK" "$GYAZO_TOKEN_REF" "$PATH"'],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    sock, ref, path = result.stdout.split("\n")[:3]
+    return {"SSH_AUTH_SOCK": sock, "GYAZO_TOKEN_REF": ref, "PATH": path}
+
+
+class SshAuthSockTest(unittest.TestCase):
+    """SSH_AUTH_SOCK の分岐。ここが崩れると無人セッションの署名が落ちる"""
+
+    def test_points_at_secretive_on_a_local_shell(self):
+        # 非対話シェルでも読まれること自体が要件 (zshrc に置くと読まれない)
+        env = source_zshenv(SSH_CONNECTION=None, SSH_AUTH_SOCK=None)
+        self.assertIn(SECRETIVE_SOCK, env["SSH_AUTH_SOCK"])
+
+    def test_overrides_a_stale_value_on_a_local_shell(self):
+        # 1Password 時代の値を引きずったセッションでも上書きされること
+        env = source_zshenv(SSH_CONNECTION=None, SSH_AUTH_SOCK="/tmp/stale-1password.sock")
+        self.assertIn(SECRETIVE_SOCK, env["SSH_AUTH_SOCK"])
+
+    def test_leaves_a_forwarded_agent_alone_over_ssh(self):
+        # SSH 越しは forwarding された agent を指している。上書きすると相手の鍵が使えなくなる
+        env = source_zshenv(
+            SSH_CONNECTION="10.0.0.1 54321 10.0.0.2 22",
+            SSH_AUTH_SOCK="/tmp/forwarded-agent.sock",
+        )
+        self.assertEqual("/tmp/forwarded-agent.sock", env["SSH_AUTH_SOCK"])
+
+
+class NonInteractiveEssentialsTest(unittest.TestCase):
+    """zshrc ではなくここに置くべきものが揃っているか"""
+
+    def test_exports_the_gyazo_token_reference(self):
+        env = source_zshenv(GYAZO_TOKEN_REF=None)
+        self.assertTrue(env["GYAZO_TOKEN_REF"].startswith("op://"))
+
+    def test_puts_the_repository_bin_on_path(self):
+        # secret-read は非対話シェルからも引ける必要がある
+        env = source_zshenv()
+        self.assertIn(str(REPO / "bin"), env["PATH"].split(":"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/zshenv
+++ b/zshenv
@@ -5,8 +5,7 @@
 # 無人セッションでは空になり、値が引けずに黙って止まっていた。
 #
 # ここに置くのは「人が打つとき以外にも要るもの」だけに絞る。プロンプト・alias・補完・
-# oh-my-zsh のような対話シェル向けの設定は zshrc のまま。SSH_AUTH_SOCK も zshrc に残す
-# (ここへ移すと、SSH 越しのシェルで forwarding された agent を上書きして壊す)。
+# oh-my-zsh のような対話シェル向けの設定は zshrc のまま。
 
 # setup リポジトリの実行ファイル (secret-read など) を PATH へ。
 # このファイルの実体 (symlink 解決後) が置かれたディレクトリ = リポジトリの根。
@@ -20,3 +19,13 @@ export PATH
 # 使う側: secret-read "$GYAZO_TOKEN_REF" — 1Password がロックされていても読めるよう
 # Keychain をキャッシュに使う。手順は gyazo-capture スキル、線引きは secret-cache-allowlist
 export GYAZO_TOKEN_REF="op://Automation/Gyazo API/credential"
+
+# SSH agent は Secretive (Secure Enclave)。ssh-keygen -Y sign は SSH_AUTH_SOCK から
+# agent を引くので、コミット署名にもこの変数が要る。zshrc に置くと非対話シェルが
+# 読まないため、無人セッションでだけ署名が落ちる (GYAZO_TOKEN_REF と同じ轍)。
+#
+# ただし SSH 越しにこのマシンへ入っているときは触らない。forwarding された agent の
+# ソケットを指しているので、上書きすると相手の鍵が使えなくなる。
+if [[ -z "$SSH_CONNECTION" ]]; then
+  export SSH_AUTH_SOCK=~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh
+fi

--- a/zshrc
+++ b/zshrc
@@ -113,11 +113,6 @@ _update_prompt_with_firebase() {
 _update_prompt_with_firebase
 
 
-# SSH agent は Secretive (Secure Enclave)。ssh-keygen -Y sign は SSH_AUTH_SOCK から
-# agent を引くので、コミット署名にもこの変数が要る。zshenv ではなくここに置くのは、
-# SSH 越しのシェルで forwarding された agent を壊さないため (zshenv:8-9 の判断を踏襲)
-export SSH_AUTH_SOCK=~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh
-
 # 秘密の参照 (GYAZO_TOKEN_REF) と setup リポジトリの PATH は zshenv へ移した。
 # 非対話シェル (Claude の hook・scheduled task・cron) は zshrc を読まないため。
 


### PR DESCRIPTION
## 目的

#95 で `SSH_AUTH_SOCK` の指し先を Secretive へ変えたが、**置き場を `zshrc` のままにしていた**。zshrc は**非対話シェルでは読まれない**ので、Claude Code の hook・scheduled task・cron から走るセッションではこの変数が設定されず、**コミット署名だけが黙って落ちる**。

`GYAZO_TOKEN_REF` が #90 で踏んだのとまったく同じ轍で、zshenv を作った理由そのものだった。

### 実際に踏んだ

この PR を作る前に全テストを流したところ **223 件中 54 件がエラー**になった。原因は古い `SSH_AUTH_SOCK` を持ったセッションで git 操作を伴うテストが署名できなかったこと。`SSH_AUTH_SOCK` を Secretive にして流し直すと **223 件すべて green**。症状が「無人セッションでだけ落ちる」形で出るのを実地で確認した。

## 変更点

- `zshenv` — `SSH_AUTH_SOCK` を追加。**ただし SSH 越しにこのマシンへ入っているときは触らない**。forwarding された agent のソケットを指しているので、上書きすると相手の鍵が使えなくなる (zshenv へ移さない理由として元のコメントが挙げていた懸念を、条件で回避した)
- `zshrc` — 同設定を削除
- `claude/tests/zshenv_test.py` (新規) — ローカルでは Secretive を指すことと、SSH 越しでは触らないことを**対で**固定した。あわせて `GYAZO_TOKEN_REF` と `bin/` の PATH も見る (zshrc に戻すと落ちる)

## 確認方法

```bash
python3 claude/tests/zshenv_test.py
```

5 件が通ること。**壊して赤くなることも確認済み**:

- `if [[ -z "$SSH_CONNECTION" ]]` を `if true` にすると SSH forwarding のテストが 1 件 FAIL
- 設定ごと削除すると 2 件 FAIL

```bash
python3 -m unittest discover -s claude/tests -p '*_test.py'
```

223 件が通ること。

Refs #91

---
<sub>🤖 Assisted by [Claude Code](https://claude.com/claude-code)</sub>
