### PR TITLE
fix(claude): plan-record.sh が投稿先を取り違えるのを直す

### DIFF
--- a/claude/plan-record.sh
+++ b/claude/plan-record.sh
@@ -132,12 +132,16 @@ emit() { # $1=種別 $2=説明 $3=本文 $4=検出パターン $5=除外パタ�
 # --- 投稿先の解決 -----------------------------------------------------------
 # 優先順は「今そこにある器」から。PR があればそこ、無ければプランが閉じようと
 # している Issue、それも無ければブランチ名の数字列。どれも無ければ空を返す。
+#
+# PR はマージ後も投稿先のまま扱う。open だけを見ると、マージした瞬間に投稿済みの
+# プランを見失い、Closes で名乗った Issue (たいてい閉じている) へ催促が回る。
+# 除くのは放棄された CLOSED だけ。
 
 resolve_target() { # $1=ブランチ $2=本文 → "pr 123" / "issue 45" / ""
   local branch="$1" body="$2" number
 
   number=$(gh pr view "$branch" --json number,state \
-    -q 'select(.state == "OPEN") | .number' 2>/dev/null)
+    -q 'select(.state != "CLOSED") | .number' 2>/dev/null)
   if [ -n "$number" ]; then
     printf 'pr %s' "$number"
     return 0
@@ -147,8 +151,15 @@ resolve_target() { # $1=ブランチ $2=本文 → "pr 123" / "issue 45" / ""
   number=$(printf '%s' "$body" |
     grep -ioE '(closes|fixes|resolves|refs|ref|issue)[[:space:]]*#[0-9]+' |
     grep -oE '[0-9]+' | head -1)
-  # 名乗りが無ければブランチ名の数字列 (issues-123 / fix/123-foo)
-  [ -n "$number" ] || number=$(printf '%s' "$branch" | grep -oE '[0-9]{1,6}' | head -1)
+  # 名乗りが無ければブランチ名の数字列 (issues-123 / fix/123-foo)。ただし採るのは
+  # 区切りに接した数字だけにする。Claude Code が切るブランチ名の末尾 hex
+  # (claude/<説明>-c936e5 → 936) や worktree の自動生成名に紛れる断片
+  # (cse_0127aTN6... → 127) を番号と読むと、無関係な Issue へプランが飛ぶ。
+  # 番号が実在することは、そこが投稿先として正しいことを意味しない
+  [ -n "$number" ] || number=$(printf '%s' "$branch" |
+    sed -E 's#^(claude/.*)-[0-9a-f]{6}$#\1#' |
+    grep -oE '(^|[^0-9A-Za-z])[0-9]{1,6}([^0-9A-Za-z]|$)' |
+    grep -oE '[0-9]+' | head -1)
   [ -n "$number" ] || return 0
 
   # 実在して open かを確かめる。ブランチ名の数字はハッシュの断片でもありうる
@@ -382,6 +393,9 @@ guard() {
 $pending
 記憶がリセットされた次のセッションは、この PR / Issue を読むだけで再開できる必要があります。
 実装の途中で方針が変わっているなら、変わった点を本文に追記してから投稿してください。
+
+上の投稿先が違うと思うなら、ブランチ名から推定した番号かもしれません。正しい PR /
+Issue へ投稿したうえで、-F に出ている記録ファイルを消せばこの差し戻しは止まります。
 
 投稿しない判断をした場合 (プランが実装と食い違って役に立たない等) は、そのまま終えて
 構いません ($MAX_NAGS 回で自動的に黙ります)。

--- a/claude/tests/plan_record_test.py
+++ b/claude/tests/plan_record_test.py
@@ -17,19 +17,39 @@ from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent.parent / "plan-record.sh"
 
-# 引数から用件だけを見分ける最小の gh。number を返す問い合わせと、コメント本文を
-# 返す問い合わせの二つしか使われない
+# 引数から用件だけを見分ける最小の gh。番号を返す問い合わせと、コメント本文を返す
+# 問い合わせの二つしか使われない。前者は state による絞り込みまで見るので、末尾の
+# -q に来る jq クエリを本物と同じように適用する
 FAKE_GH = """#!/bin/sh
 kind=$1
+query=.
+prev=
+for arg in "$@"; do
+  [ "$prev" = "-q" ] && query=$arg
+  prev=$arg
+done
 case "$*" in
   *comments*) printf '%s\\n' "${FAKE_GH_COMMENTS:-}"; exit 0 ;;
 esac
+json=
 case "$kind" in
-  pr)    [ -n "${FAKE_GH_PR:-}" ]    || exit 1; printf '%s\\n' "$FAKE_GH_PR" ;;
-  issue) [ -n "${FAKE_GH_ISSUE:-}" ] || exit 1; printf '%s\\n' "$FAKE_GH_ISSUE" ;;
-  *) exit 1 ;;
+  # FAKE_GH_PR は「open な PR がその番号」の近道。state を変えたいときは
+  # FAKE_GH_PR_JSON へ {"number":n,"state":"MERGED"} のように直接置く
+  pr)
+    json=${FAKE_GH_PR_JSON:-}
+    [ -n "$json" ] || [ -z "${FAKE_GH_PR:-}" ] || json='{"number":'$FAKE_GH_PR',"state":"OPEN"}'
+    ;;
+  issue)
+    json=${FAKE_GH_ISSUE_JSON:-}
+    [ -n "$json" ] || [ -z "${FAKE_GH_ISSUE:-}" ] || json='{"number":'$FAKE_GH_ISSUE'}'
+    ;;
 esac
+[ -n "$json" ] || exit 1
+printf '%s' "$json" | jq -r "$query"
 """
+
+MERGED_PR = '{"number":108,"state":"MERGED"}'
+CLOSED_PR = '{"number":108,"state":"CLOSED"}'
 
 
 class PlanRecordTestCase(unittest.TestCase):
@@ -295,6 +315,58 @@ class PlanRecordTestCase(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertIn("無効化されている", result.stderr)
 
+    # --- 投稿先の解決 -------------------------------------------------------
+
+    def test_capture_posts_to_a_merged_pull_request(self):
+        # マージすると PR は MERGED になる。ここで見失うと、規約どおり PR へ
+        # 投稿を済ませたセッションほど閉じた Issue へ催促される
+        result = self.capture(
+            "Closes #77 のための計画。\n", FAKE_GH_PR_JSON=MERGED_PR, FAKE_GH_ISSUE="77"
+        )
+        self.assertIn("gh pr comment 108", result.stderr)
+        self.assertNotIn("issue comment", result.stderr)
+
+    def test_capture_skips_an_abandoned_pull_request(self):
+        # 放棄された PR (CLOSED) は器として死んでいるので、名乗った Issue へ回す
+        result = self.capture(
+            "Closes #77 のための計画。\n", FAKE_GH_PR_JSON=CLOSED_PR, FAKE_GH_ISSUE="77"
+        )
+        self.assertIn("gh issue comment 77", result.stderr)
+
+    def test_guard_clears_a_record_posted_to_a_merged_pull_request(self):
+        self.capture("計画。\n", FAKE_GH_PR_JSON=MERGED_PR)
+        record_id = self.records()[0].read_text().split("plan-record: ")[1].split(" ")[0]
+
+        result = self.guard(
+            FAKE_GH_PR_JSON=MERGED_PR,
+            FAKE_GH_COMMENTS=f"<!-- plan-record: {record_id} -->",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.records(), [])
+
+    def test_capture_ignores_a_hex_suffix_in_the_branch_name(self):
+        # claude/<説明>-<6 桁 hex>。936 は無関係な Issue として実在しうるので、
+        # 実在確認を通り抜けてプランが撃ち込まれる
+        self.git("checkout", "-q", "-b", "claude/batch-issue-cleanup-c936e5")
+        result = self.capture("名乗りの無い計画。\n", FAKE_GH_ISSUE="936")
+        self.assertIn("まだありません", result.stderr)
+        self.assertNotIn("936", result.stderr)
+
+    def test_capture_ignores_digits_glued_to_letters_in_the_branch_name(self):
+        # worktree の自動生成名。0127 は英字に挟まれたハッシュの断片
+        self.git("checkout", "-q", "-b", "worktree-bridge-cse_0127aTN6krq7fqrr56rh6gbc")
+        result = self.capture("名乗りの無い計画。\n", FAKE_GH_ISSUE="127")
+        self.assertIn("まだありません", result.stderr)
+        self.assertNotIn("127", result.stderr)
+
+    def test_capture_still_reads_a_delimited_number_from_the_branch_name(self):
+        # 区切りに接した数字は従来どおり拾う (推定の親切さを落とさない)
+        for branch in ("issues-123", "fix/123-foo", "claude/fix-123-c936e5"):
+            with self.subTest(branch=branch):
+                self.git("checkout", "-q", "-b", branch)
+                result = self.capture("名乗りの無い計画。\n", FAKE_GH_ISSUE="123")
+                self.assertIn("gh issue comment 123", result.stderr)
+
     # --- guard --------------------------------------------------------------
 
     def test_guard_blocks_stop_while_the_plan_is_unposted(self):
@@ -332,6 +404,13 @@ class PlanRecordTestCase(unittest.TestCase):
         # 4 回目は諦めて人間の判断へ返す (無限に終われないセッションを作らない)
         self.assertEqual(self.guard(FAKE_GH_PR="42").returncode, 0)
         self.assertEqual(self.records(), [])
+
+    def test_guard_shows_how_to_escape_a_wrong_target(self):
+        # 投稿先の推定が外れたとき、差し戻しを読むだけで抜けられる必要がある
+        self.capture("計画。\n", FAKE_GH_PR="42")
+        result = self.guard(FAKE_GH_PR="42")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("投稿先が違う", result.stderr)
 
     def test_guard_can_be_disabled(self):
         self.capture("計画。\n", FAKE_GH_PR="42")


### PR DESCRIPTION
## 目的

着手時のプランの投稿先を解決する `resolve_target()` が、2 つの経路で誤った先を指していた。片方は無駄な差し戻しで済むが、もう片方は**無関係な Issue へ長文のプランを撃ち込みうる**。

- #84 — マージ済み PR を見失い、閉じた Issue へ催促を回す
- #89 / #96 — ブランチ名の hex 断片を Issue 番号と誤認する (同一原因なのでまとめて直す)

## 変更点

**1. マージ済み PR を投稿先のまま扱う (#84)**

`select(.state == "OPEN")` → `select(.state != "CLOSED")`。squash merge した瞬間に PR 上の marker が読めなくなり、`Closes #N` で名乗った Issue へフォールバックしていた。規約どおり PR へ投稿を済ませたセッションほど終了時に催促される、という逆転が消える。放棄された CLOSED PR は従来どおり除く。

**2. ブランチ名からの誤認を止める (#89 / #96)**

末尾の hex サフィックス (`claude/<説明>-c936e5`) を落としてから、**区切りに接した数字だけ**を採る。

| ブランチ名 | 変更前 | 変更後 |
|---|---|---|
| `claude/batch-issue-cleanup-c936e5` | `936` | (採らない) |
| `worktree-bridge-cse_0127aTN6krq7fqrr56rh6gbc` | `127` | (採らない) |
| `issues-123` / `fix/123-foo` / `feat/plan-123` | `123` | `123` |
| `claude/fix-123-c936e5` | `123` | `123` |

純粋な数字サフィックス (`fix/issue-100000`) を hex と誤って落とさないよう、サフィックス除去は `claude/` 始まりの 6 桁 hex に限っている。

**3. 推定が外れたときの抜け方を差し戻し文に書く (#96 の「あわせて考えたい点」)**

「正しい PR / Issue へ投稿したうえで記録ファイルを消せば止まる」の一行。#96 では `resolve_target` を読んで初めて誤認と分かった。

## 確認方法

```bash
python3 claude/tests/plan_record_test.py -v          # 30 tests
python3 -m unittest discover -s claude/tests -p '*_test.py'   # 230 tests
```

テスト側は偽 gh が `-q` の jq クエリを実際に適用するようにして、state を見分けられるようにした (従来は `FAKE_GH_PR` をそのまま返すだけで OPEN / MERGED を区別できなかった)。追加した 6 ケースは #84 / #89 / #96 の実例をそのまま使っており、**実装前に流して赤くなることを確認済み**。既存 23 ケースは無変更で通る。

`shellcheck claude/plan-record.sh` は変更箇所に指摘なし (既存の SC2164 が 250 行に 1 件残るが、本 PR の関心外)。

---
<sub>🤖 Assisted by [Claude Code](https://claude.com/claude-code)</sub>