### PR TITLE
docs(claude): 保護設定の標準を ruleset 一本化で書き切る

### DIFF
--- a/claude/repo-standards.json
+++ b/claude/repo-standards.json
@@ -381,8 +381,8 @@
       "level": "required",
       "applies_to": ["all"],
       "check": { "type": "builtin", "name": "main_branch_protected" },
-      "why": "main への force push・削除を機械的に禁止する (不可逆操作の仕組み化)",
-      "fix": "enforcement=active で ~DEFAULT_BRANCH を対象に deletion + non_fast_forward ルールを持つ ruleset を作成する (gh api -X POST repos/{repo}/rulesets --input -)",
+      "why": "main への force push・削除を機械的に禁止する (不可逆操作の仕組み化)。保護は ruleset に一本化する — classic branch protection と併用すると同じ制約が二箇所に散り、どちらが効いているか読めなくなる",
+      "fix": "enforcement=active で ~DEFAULT_BRANCH を対象に deletion + non_fast_forward ルールを持つ ruleset を作成する (gh api -X POST repos/{repo}/rulesets --input -)。classic branch protection で運用しているリポは、同じ制約の ruleset を作って classic 側から降ろす (保護が一時的に緩む操作なので人の判断で行う)",
       "fix_kind": "deterministic"
     },
     {
@@ -392,7 +392,7 @@
       "applies_to": ["all"],
       "check": { "type": "builtin", "name": "main_pr_required" },
       "why": "main へは PR 経由 (approve 0 で可)。手入れされたリポ (metaphor / claude-plugins / skopos) が全て採用している",
-      "fix": "ruleset に pull_request ルール (required_approving_review_count: 0) を追加する",
+      "fix": "ruleset に pull_request ルール (required_approving_review_count: 0) を追加する。classic 側で満たしている場合も ruleset へ移す",
       "fix_kind": "deterministic"
     },
     {
@@ -402,7 +402,7 @@
       "applies_to": ["all"],
       "check": { "type": "builtin", "name": "required_checks_configured" },
       "why": "CI green をマージ条件にする (auto-merge の判定にも使われる)。手入れされたリポが全て採用している",
-      "fix": "ruleset に required_status_checks を追加し CI の必須ジョブ名を登録する",
+      "fix": "ruleset に required_status_checks を追加し CI の必須ジョブ名を登録する。classic 側で満たしている場合も ruleset へ移す",
       "fix_kind": "generative"
     },
     {
@@ -412,7 +412,7 @@
       "applies_to": ["all"],
       "check": { "type": "builtin", "name": "main_signatures_required" },
       "why": "コミットの出所を保証する。ローカルは全コミット署名の運用なので、その最終ゲートをリポジトリ側に置く",
-      "fix": "ruleset に required_signatures を追加する (ローカルの署名設定が前提)",
+      "fix": "ruleset に required_signatures を追加する (ローカルの署名設定が前提)。classic 側で満たしている場合も ruleset へ移す",
       "fix_kind": "deterministic"
     },
     {
@@ -422,7 +422,7 @@
       "applies_to": ["all"],
       "check": { "type": "builtin", "name": "main_linear_history" },
       "why": "squash merge 前提なら履歴は直線になるはずで、崩れていれば運用が漏れている証拠になる",
-      "fix": "ruleset に required_linear_history を追加する",
+      "fix": "ruleset に required_linear_history を追加する。classic 側で満たしている場合も ruleset へ移す",
       "fix_kind": "deterministic"
     },
     {
@@ -432,7 +432,7 @@
       "applies_to": ["all"],
       "check": { "type": "builtin", "name": "tag_protection" },
       "why": "公開済みタグの改変・削除は利用者のビルドを壊す不可逆操作 (タグが無いリポは対象外)",
-      "fix": "target: tag / include: refs/tags/v* で deletion + non_fast_forward + update の ruleset を作る",
+      "fix": "target: tag / include: refs/tags/v* で deletion + non_fast_forward + update の ruleset を作る (classic の tag protection rules ではなく ruleset で持つ)",
       "fix_kind": "deterministic"
     },
     {


### PR DESCRIPTION
## 目的

判定ロジックは claude-plugins#53 で ruleset / classic のどちらでも成立するようになったが、正本の fix 文言は ruleset 前提のまま残っていた。classic branch protection で運用しているリポ (例: shinyaoguri/dropcaster) で warn が出たとき、**案内どおり ruleset を足すと classic と二重管理**になる。

方針を **ruleset へ統一**と決めたので (#55 の提案 3)、その形で書き切る。

Closes #55

## 変更点

保護設定に関わる 6 項目の文言。

- **`gh-main-protected`** — 保護設定の起点なので、ここに方針そのものを置いた
  - `why` に一本化の理由: 「classic branch protection と併用すると同じ制約が二箇所に散り、どちらが効いているか読めなくなる」
  - `fix` に classic からの移行: 「同じ制約の ruleset を作って classic 側から降ろす (保護が一時的に緩む操作なので人の判断で行う)」
- **`gh-pr-required` / `gh-required-checks` / `gh-signatures-required` / `gh-linear-history`** — 「classic 側で満たしている場合も ruleset へ移す」を添えた。判定が通っていても移行対象だと読める
- **`gh-tag-protection`** — classic の tag protection rules ではなく ruleset で持つことを明示

`fix_kind` は変えていない。主たる fix (新規に ruleset を作る) は決定論的で、classic からの移行はそのリポでだけ生じる補足だから。移行に伴う保護の撤去が人の判断だという点は fix 文に書いた。

## この PR で触らないこと

判定を「classic のままなら移行を促す」側へ変えるには、項目の新設 (`classic branch protection を使っていない`) と claude-plugins 側の builtin 実装が要る。#55 は fix 文言の Issue なのでここでは触らず、別途起票する。現状は classic で満たしていれば ok のままなので、**移行の必要性は監査に出てこない**。

## 確認方法

```bash
python3 claude/tests/repo_standards_test.py -v   # 13 tests, OK
```

文言のみの変更で振る舞いは変わらないため、テストは足していない (JSON の整合と `fix_kind` の分類は既存テストが見ている)。

---
<sub>🤖 Assisted by [Claude Code](https://claude.com/claude-code)</sub>