### PR TITLE
chore(claude): op read の allow を外し、secret-read 経由を実行時に効かせる

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -33,7 +33,6 @@
       "Bash(gh pr view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr diff:*)",
-      "Bash(op read:*)",
       "Bash(secret-read:*)"
     ],
     "additionalDirectories": [

--- a/claude/tests/settings_test.py
+++ b/claude/tests/settings_test.py
@@ -106,6 +106,29 @@ class SettingsTestCase(unittest.TestCase):
     def test_allow_rules_unique(self):
         self.assertEqual(len(self.allow), len(set(self.allow)), "allow が重複している")
 
+    def test_op_read_is_not_allowed_directly(self):
+        """1Password の秘密は secret-read 経由で読む (op read を素通しにしない)。
+
+        `op read` は 1Password がロックされていると承認ダイアログを出したまま返らない
+        (実測で 2 分以上ハングした)。無人セッション (hook・scheduled task・バックグラウンド)
+        は承認に応えられないので、そこで黙って止まる。`secret-read` は許可した参照だけを
+        Keychain にキャッシュするのでロックに左右されず、正本のローテートにも追随する。
+
+        allow に `op read` があると、その違いを意識しないまま直接呼べてしまい、規約は
+        CLAUDE.md に書いてあるだけになる。**ここで外しておけば、直接呼んだときだけ承認が
+        求められる** — 文書ルールが実行時の判定に降りる。
+
+        `secret-read` が内部で呼ぶ `op read` はシェルスクリプトの中なので、この判定は
+        通らない (影響を受けない)。
+        """
+        for rule in self.allow:
+            with self.subTest(rule=rule):
+                self.assertNotRegex(
+                    rule,
+                    r"^Bash\(\s*op\s+read",
+                    "op read は allow に置かない (secret-read を使う)",
+                )
+
 
 class AdditionalDirectoriesTestCase(unittest.TestCase):
     """`permissions.additionalDirectories` のテスト。


### PR DESCRIPTION
## 目的

「1Password の秘密は `op read` ではなく `secret-read` で読む」は CLAUDE.md に書いてあるだけで、
allow に `Bash(op read:*)` があるために**実行時には何も止めていませんでした**。

Gyazo トークンの読み取り経路を総点検したところ、実際に複数の場所が `op read` 直のまま
残っていました。文書ルールだけでは守られない、という実例です。

## なぜ止めたいか

`op read` は 1Password がロックされていると承認ダイアログを出したまま返りません
（setup#107 の検証中に**実測で 2 分以上ハング**しました）。無人セッション（hook・
scheduled task・バックグラウンド）は承認に応えられないので、そこで黙って止まります。

`secret-read` は許可した参照だけを Keychain にキャッシュするのでロックに左右されず、
正本（1Password）のローテートにも 24 時間で追随します。

## 変更点

- `claude/settings.json` の allow から `Bash(op read:*)` を落とす
- `claude/tests/settings_test.py` に「allow へ `op read` を置かない」を足す

allow から外すと、**直接 `op read` と打ったときだけ承認が求められる**ようになります。
文書ルールが実行時の判定に降りる、いつもの形です。

`secret-read` が内部で呼ぶ `op read` はシェルスクリプトの中なので、この判定は通りません
（＝影響を受けません）。allowlist に載っていない参照を読む経路も、`secret-read` が
素通しで `op` を呼ぶので従来どおり動きます。

## 確認方法

```bash
python3 -m unittest discover -s claude/tests -p '*_test.py'
```

248 件 green。新しいテストは、`Bash(op read:*)` を settings.json へ戻すと赤くなることを
確認済みです。